### PR TITLE
[sonic-cfggen] Mellanox  add code to read base mac from machine.conf

### DIFF
--- a/src/sonic-config-engine/sonic_device_util.py
+++ b/src/sonic-config-engine/sonic_device_util.py
@@ -48,7 +48,7 @@ def get_system_mac():
     version_info = get_sonic_version_info()
 
     if (version_info['asic_type'] == 'mellanox'):
-        # With latest Mellanox ONIE release(2019.05-5.2.0012)
+        # With Mellanox ONIE release(2019.05-5.2.0012) and above
         # "onie_base_mac" was added to /host/machine.conf:
         # onie_base_mac=e4:1d:2d:44:5e:80
         # So we have another way to get the mac address besides decode syseeprom

--- a/src/sonic-config-engine/sonic_device_util.py
+++ b/src/sonic-config-engine/sonic_device_util.py
@@ -48,7 +48,19 @@ def get_system_mac():
     version_info = get_sonic_version_info()
 
     if (version_info['asic_type'] == 'mellanox'):
-        get_mac_cmd = "sudo decode-syseeprom -m"
+        # With latest Mellanox ONIE release(2019.05-5.2.0012)
+        # "onie_base_mac" was added to /host/machine.conf:
+        # onie_base_mac=e4:1d:2d:44:5e:80
+        # So we have another way to get the mac address besides decode syseeprom
+        # By this can mitigate the dependency on the hw-management service
+        base_mac_key = "onie_base_mac"
+        machine_vars = get_machine_info()
+        if machine_vars is not None and base_mac_key in machine_vars:
+            mac = machine_vars[base_mac_key]
+            mac = mac.strip()
+            return mac
+        else:
+            get_mac_cmd = "sudo decode-syseeprom -m"
     else:
         get_mac_cmd = "ip link show eth0 | grep ether | awk '{print $2}'"
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
        With Mellanox ONIE release(2019.05-5.2.0012) and above, "onie_base_mac" was added to "/host/machine.conf":   onie_base_mac=e4:1d:2d:44:5e:80
        So now on Mellanox platform, we have another way to get the mac address besides decode syseeprom, by this can mitigate the dependency on the hw-management service.

**- How I did it**

add code the get_sys_mac() for Mellanox platform to check whether can get mac directly from machine.conf, if not, fall back on the old way.

**- How to verify it**

run "sonic-cfggen -H --print-data" with the new code

```
root@mtbc-sonic-03-2700:/tmp# sonic-cfggen -H --print-data
{
    "DEVICE_METADATA": {
        "localhost": {
            "mac": "e4:1d:2d:44:5e:80", 
            "platform": "x86_64-mlnx_msn2700-r0"
        }
    }
}
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
