### PR TITLE
[Mellanox] Sfplpmode rule out CPU ports to avoid any operation on them

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/sfplpmset.py
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/sfplpmset.py
@@ -18,13 +18,18 @@ PMAOS_RST = 0
 PMAOS_ENABLE = 1
 PMAOS_DISABLE = 2
 
+PORT_TYPE_CPU = 4
 PORT_TYPE_NVE = 8
 PORT_TYPE_OFFSET = 28
 PORT_TYPE_MASK = 0xF0000000
 NVE_MASK = PORT_TYPE_MASK & (PORT_TYPE_NVE << PORT_TYPE_OFFSET)
+CPU_MASK = PORT_TYPE_MASK & (PORT_TYPE_CPU << PORT_TYPE_OFFSET)
 
 def is_nve(port):
     return (port & NVE_MASK) != 0
+
+def is_cpu(port):
+    return (port & CPU_MASK) != 0
 
 def is_port_admin_status_up(log_port):
     oper_state_p = new_sx_port_oper_state_t_p()
@@ -57,6 +62,7 @@ def get_log_ports(handle, sfp_module):
     for i in range(0, port_cnt):
         port_attributes = sx_port_attributes_t_arr_getitem(port_attributes_list, i)
         if is_nve(int(port_attributes.log_port)) == False \
+           and is_cpu(int(port_attributes.log_port)) == False \
            and port_attributes.port_mapping.module_port == sfp_module \
            and is_port_admin_status_up(port_attributes.log_port):
             log_port_list.append(port_attributes.log_port)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Add logic to rule out all CPU ports to avoid any operation on them, SDK API called in the lpmode set scripts not applicable to them and will cause SDK error log.
 
**- How I did it**
Judge the port type to see if it is CPU port, if CPU port then skip it.

**- How to verify it**
run "sfputil lpmode on/off EthernetX" command to test

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
