### PR TITLE
[Mellanox] remove code which instructs hw-mgmt to skip mlsw_minimal probing in fast-boot flow

### DIFF
--- a/files/scripts/syncd.sh
+++ b/files/scripts/syncd.sh
@@ -109,10 +109,6 @@ start() {
             fi
         fi
 
-        if [[ x"$BOOT_TYPE" == x"fast" ]]; then
-            /usr/bin/hw-management.sh chipupdis
-        fi
-
         /usr/bin/mst start --with_i2cdev
         /usr/bin/mlnx-fw-upgrade.sh
         /etc/init.d/sxdkernel start


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- Why I did it**

In Mellanox fast-reboot flow, there is code to instruct hw-mgmt to skip mlsw_minimal probing, due to the optimization of SDK and hw-mgmt, these codes is not needed anymore, and could cause issue in the fast-reboot case, they need to be removed.

**- How I did it**

remove related from syncd.sh

**- How to verify it**

run fast-reboot and check if everything is OK.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
