### PR TITLE
[Mellanox] [platform API]: fix local variable 'lable_port' referenced before assignment error

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/sfp_event.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/sfp_event.py
@@ -278,6 +278,7 @@ class sfp_event:
         port_cnt_p = new_uint32_t_p()
         uint32_t_p_assign(port_cnt_p,64)
         label_port_list = []
+        label_port = None
         module_state = 0
 
         rc = sx_lib_host_ifc_recv(fd_p, pkt, pkt_size_p, recv_info_p)
@@ -309,9 +310,11 @@ class sfp_event:
                 for i in range(port_cnt):
                     port_attributes = sx_port_attributes_t_arr_getitem(port_attributes_list,i)
                     if port_attributes.log_port == logical_port:
-                        lable_port = port_attributes.port_mapping.module_port
+                        label_port = port_attributes.port_mapping.module_port
                         break
-                label_port_list.append(lable_port)
+
+                if label_port is not None:
+                    label_port_list.append(label_port)
 
         delete_uint32_t_p(pkt_size_p)
         delete_uint8_t_arr(pkt)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**

 In rare case can see that xcvrd failed due to "UnboundLocalError: local variable 'lable_port' referenced before assignment"

**- How I did it**

Init "lable_port" as None at the beginning of the function, to avoid the case that "label_port" not assigned.

**- How to verify it**

run SFP related test.

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
