### PR TITLE
[Mellanox][platform api] fix a missing time module import

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/eeprom.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/eeprom.py
@@ -8,6 +8,7 @@
 import os
 import sys
 import re
+import time
 
 if sys.version_info.major == 3:
     from io import StringIO


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**

"time" module was missed to be imported and will cause an error when the code executed.

**- How I did it**

Adding "import time"

**- How to verify it**

make the condition to be true by mocking and let the code run, can see it run w/o error.

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [ ] 202006
- [ ] 202012

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
