### PR TITLE
[Mellanox] Add hw-mgmt patch to support SDK OFFLINE event handling during ISSU

### DIFF
--- a/platform/mellanox/hw-management/0002-hw-mgmt-events-Add-support-for-SDK-OFFLINE-event-for.patch
+++ b/platform/mellanox/hw-management/0002-hw-mgmt-events-Add-support-for-SDK-OFFLINE-event-for.patch
@@ -1,0 +1,30 @@
+From 3e511778248403968e0a02857b7003f352669ba3 Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@nvidia.com>
+Date: Wed, 13 Jan 2021 13:19:17 +0200
+Subject: [PATCH] hw-mgmt: events: Add support for SDK OFFLINE event for
+ handling flow with in service firmware upgrade
+
+In order to prevent "mlxsw_minimal" driver access to ASIC during in
+service firmware upgrade flow, SDK will raise "OFFLINE" 'udev' event
+at early beginning of such flow. When this event is received,
+hw-managemnet will remove "mlxsw_minimal" driver.
+There is no need to implement opposite "ONLINE" event, since this flow
+is ended up with "kexec".
+
+Signed-off-by: Vadim Pasternak <vadimp@mellanox.com>
+---
+ usr/lib/udev/rules.d/50-hw-management-events.rules | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/usr/lib/udev/rules.d/50-hw-management-events.rules b/usr/lib/udev/rules.d/50-hw-management-events.rules
+index cf4219e..33ea1bc 100644
+--- a/usr/lib/udev/rules.d/50-hw-management-events.rules
++++ b/usr/lib/udev/rules.d/50-hw-management-events.rules
+@@ -269,3 +269,4 @@ SUBSYSTEM=="i2c", DEVPATH=="/devices/platform/mlxplat/i2c_mlxcpld*/i2c-*/i2c-*/*
+ # SDK
+ SUBSYSTEM=="pci", DRIVERS=="sx_core", ACTION=="add", RUN+="/usr/bin/hw-management-thermal-events.sh add sxcore add"
+ SUBSYSTEM=="pci", DRIVERS=="sx_core", ACTION=="remove", RUN+="/usr/bin/hw-management-thermal-events.sh rm sxcore remove"
++SUBSYSTEM=="pci", DRIVERS=="sx_core", ACTION=="offline", RUN+="/usr/bin/hw-management-thermal-events.sh rm sxcore remove"
+-- 
+1.9.1
+


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**

During ISSU, "mlxsw_minimal" driver still trying to access firmware, in some cases FW could return some wrong critical threshold value which will cause switch shutdown.

**- How I did it**

In order to prevent "mlxsw_minimal" driver from accessing ASIC during ISSU, SDK will raise "OFFLINE" 'udev' event
at the early beginning of such flow. When this event is received, hw-managemnet will remove "mlxsw_minimal" driver.
There is no need to implement the opposite "ONLINE" event since this flow is ended up with "kexec".

**- How to verify it**

repeatedly perform warm reboot, make sure there is no switch shutdown occurred.

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
