### PR TITLE
[Mellanox] Add sensor conf for SN4600C A1 platform

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn4600c-r0/get_sensors_conf_path
+++ b/device/mellanox/x86_64-mlnx_msn4600c-r0/get_sensors_conf_path
@@ -1,0 +1,1 @@
+../x86_64-mlnx_msn4700-r0/get_sensors_conf_path

--- a/device/mellanox/x86_64-mlnx_msn4600c-r0/sensors.conf.a1
+++ b/device/mellanox/x86_64-mlnx_msn4600c-r0/sensors.conf.a1
@@ -1,0 +1,133 @@
+################################################################################
+# Copyright (c) 2020 Mellanox Technologies
+#
+# Platform specific sensors config for SN4600C
+################################################################################
+
+# Temperature sensors
+bus "i2c-2" "i2c-1-mux (chan_id 1)"
+    chip "mlxsw-i2c-*-48"
+        label temp1 "Ambient ASIC Temp"
+
+bus "i2c-7" "i2c-1-mux (chan_id 6)"
+    chip "tmp102-i2c-*-49"
+        label temp1 "Ambient Fan Side Temp (air intake)"
+    chip "tmp102-i2c-*-4a"
+        label temp1 "Ambient Port Side Temp (air exhaust)"
+
+bus "i2c-15" "i2c-1-mux (chan_id 6)"
+    chip "tmp102-i2c-15-49"
+        label temp1 "Ambient COMEX Temp"
+
+# Power controllers
+bus "i2c-5" "i2c-1-mux (chan_id 4)"
+    chip "mp2975-i2c-*-62"
+        label in1 "PMIC-1 PSU 12V Rail (in1)"
+        label in2 "PMIC-1 ASIC 0.8V VCORE MAIN Rail (out)"
+        label temp1 "PMIC-1 Temp 1"
+        label power1 "PMIC-1 PSU 12V Rail Pwr (in1)"
+        label power2 "PMIC-1 ASIC 0.8V VCORE MAIN Rail Pwr (out)"
+        label curr1 "PMIC-1 PSU 12V Rail Curr (in1)"
+        label curr2 "PMIC-1 ASIC 0.8V VCORE MAIN Rail Curr (out)"
+    chip "mp2975-i2c-*-64"
+        label in1 "PMIC-2 PSU 12V Rail (in1)"
+        label in2 "PMIC-2 ASIC 1.8V VCORE MAIN Rail (out)"
+        label in3 "PMIC-2 ASIC 1.2V VCORE MAIN Rail (out)"
+        label temp1 "PMIC-2 Temp 1"
+        label power1 "PMIC-2 PSU 12V Rail Pwr (in1)"
+        label power2 "PMIC-2 ASIC 1.8V VCORE MAIN Rail Pwr (out)"
+        label curr1 "PMIC-2 PSU 12V Rail Curr (in1)"
+        label curr2 "PMIC-2 ASIC 1.8V VCORE MAIN Rail Curr (out)"
+        label curr3 "PMIC-2 ASIC 1.2V VCORE MAIN Rail Curr (out)"
+    chip "mp2975-i2c-*-66"
+        label in1 "PMIC-3 PSU 12V Rail (in1)"
+        label in2 "PMIC-3 ASIC 0.85V T0_1 Rail (out)"
+        label in3 "PMIC-3 ASIC 1.8V T0_1 Rail (out)"
+        label temp1 "PMIC-3 Temp 1"
+        label power1 "PMIC-3 PSU 12V Rail Pwr (in1)"
+        label power2 "PMIC-3 ASIC 0.85V T0_1 Rail Pwr (out)"
+        label curr1 "PMIC-3 PSU 12V Rail Curr (in1)"
+        label curr2 "PMIC-3 ASIC 0.85V T0_1 Rail Curr (out)"
+        label curr3 "PMIC-3 ASIC 1.8V T0_1 Rail Curr (out)"
+    chip "mp2975-i2c-*-6a"
+        label in1 "PMIC-4 PSU 12V Rail (in1)"
+        label in2 "PMIC-4 ASIC 0.85V T2_3 Rail (out)"
+        label in3 "PMIC-4 ASIC 1.8V T2_3 Rail (out)"
+        label temp1 "PMIC-4 Temp 1"
+        label power1 "PMIC-4 PSU 12V Rail Pwr (in1)"
+        label power2 "PMIC-4 ASIC 0.85V T2_3 Rail Pwr (out)"
+        label curr1 "PMIC-4 PSU 12V Rail Curr (in1)"
+        label curr2 "PMIC-4 ASIC 0.85V T2_3 Rail Curr (out)"
+        label curr3 "PMIC-4 ASIC 1.8V T2_3 Rail Curr (out)"
+    chip "mp2975-i2c-*-6e"
+        label in1 "PMIC-5 PSU 12V Rail (in1)"
+        label in2 "PMIC-5 ASIC 1.2V T0_3 Rail_1 (out)"
+        label in3 "PMIC-5 ASIC 1.2V T4_7 Rail_2 (out)"
+        label temp1 "PMIC-5 Temp 1"
+        label power1 "PMIC-5 PSU 12V Rail Pwr (in1)"
+        label power2 "PMIC-5 ASIC 1.2V T0_3 Rail_1 Pwr (out)"
+        label power3 "PMIC-5 ASIC 1.2V T4_7 Rail_2 Pwr (out)"
+        label curr1 "PMIC-5 PSU 12V Rail Curr (in1)"
+        label curr2 "PMIC-5 ASIC 1.2V T0_3 Rail_1 Curr (out)"
+        label curr3 "PMIC-5 ASIC 1.2V T4_7 Rail_2 Curr (out)"
+
+bus "i2c-15" "i2c-1-mux (chan_id 6)"
+    chip "tps53679-i2c-*-58"
+        label in1 "PMIC-6 PSU 12V Rail (in1)"
+        label in2 "PMIC-6 PSU 12V Rail (in2)"
+        label in3 "PMIC-6 COMEX 1.8V Rail (out)"
+        label in4 "PMIC-6 COMEX 1.05V Rail (out)"
+        label temp1 "PMIC-6 Temp 1"
+        label temp2 "PMIC-6 Temp 2"
+        label power1 "PMIC-6 COMEX 1.8V Rail Pwr (out)"
+        label power2 "PMIC-6 COMEX 1.05V Rail Pwr (out)"
+        label curr1 "PMIC-6 COMEX 1.8V Rail Curr (out)"
+        label curr2 "PMIC-6 COMEX 1.05V Rail Curr (out)"
+    chip "tps53679-i2c-*-61"
+        label in1 "PMIC-7 PSU 12V Rail (in1)"
+        label in2 "PMIC-7 PSU 12V Rail (in2)"
+        label in3 "PMIC-7 COMEX 1.2V Rail (out)"
+        ignore in4
+        label temp1 "PMIC-7 Temp 1"
+        label temp2 "PMIC-7 Temp 2"
+        label power1 "PMIC-7 COMEX 1.2V Rail Pwr (out)"
+        ignore power2
+        label curr1 "PMIC-7 COMEX 1.2V Rail Curr (out)"
+        ignore curr2
+
+# Power supplies
+bus "i2c-4" "i2c-1-mux (chan_id 3)"
+    chip "dps460-i2c-*-58"
+        label in1 "PSU-1(L) 220V Rail (in)"
+        ignore in2
+        label in3 "PSU-1(L) 12V Rail (out)"
+        label fan1 "PSU-1(L) Fan 1"
+        ignore fan2
+        ignore fan3
+        label temp1 "PSU-1(L) Temp 1"
+        label temp2 "PSU-1(L) Temp 2"
+        label temp3 "PSU-1(L) Temp 3"
+        label power1 "PSU-1(L) 220V Rail Pwr (in)"
+        label power2 "PSU-1(L) 12V Rail Pwr (out)"
+        label curr1 "PSU-1(L) 220V Rail Curr (in)"
+        label curr2 "PSU-1(L) 12V Rail Curr (out)"
+    chip "dps460-i2c-*-59"
+        label in1 "PSU-2(R) 220V Rail (in)"
+        ignore in2
+        label in3 "PSU-2(R) 12V Rail (out)"
+        label fan1 "PSU-2(R) Fan 1"
+        ignore fan2
+        ignore fan3
+        label temp1 "PSU-2(R) Temp 1"
+        label temp2 "PSU-2(R) Temp 2"
+        label temp3 "PSU-2(R) Temp 3"
+        label power1 "PSU-2(R) 220V Rail Pwr (in)"
+        label power2 "PSU-2(R) 12V Rail Pwr (out)"
+        label curr1 "PSU-2(R) 220V Rail Curr (in)"
+        label curr2 "PSU-2(R) 12V Rail Curr (out)"
+
+# Chassis fans
+chip "mlxreg_fan-isa-*"
+    label fan1 "Chassis Fan Drawer-1"
+    label fan2 "Chassis Fan Drawer-2"
+    label fan3 "Chassis Fan Drawer-3"


### PR DESCRIPTION
Signed-off-by: Kebo Liu <kebol@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Add sensor conf for a new SN4600C A1 platform

#### How I did it

add a sensor conf file and get_sensors_conf_path scripts to help the platform load correct sensor conf for A0/A1 platform.

#### How to verify it

run sensor test on the new A1 platform

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [X] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

