### PR TITLE
[Mellanox] update system_health_monitoring_config for MSN4410/MSN4600/MSN4700 

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn4410-r0/system_health_monitoring_config.json
+++ b/device/mellanox/x86_64-mlnx_msn4410-r0/system_health_monitoring_config.json
@@ -1,1 +1,11 @@
-../x86_64-mlnx_msn2700-r0/system_health_monitoring_config.json
+{
+    "services_to_ignore": [],
+    "devices_to_ignore": [],
+    "user_defined_checkers": [],
+    "polling_interval": 60,
+    "led_color": {
+        "fault": "orange",
+        "normal": "green",
+        "booting": "orange_blink"
+    }
+}

--- a/device/mellanox/x86_64-mlnx_msn4600-r0/system_health_monitoring_config.json
+++ b/device/mellanox/x86_64-mlnx_msn4600-r0/system_health_monitoring_config.json
@@ -1,1 +1,1 @@
-../x86_64-mlnx_msn2700-r0/system_health_monitoring_config.json
+../x86_64-mlnx_msn4410-r0/system_health_monitoring_config.json

--- a/device/mellanox/x86_64-mlnx_msn4700-r0/system_health_monitoring_config.json
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/system_health_monitoring_config.json
@@ -1,1 +1,1 @@
-../x86_64-mlnx_msn2700-r0/system_health_monitoring_config.json
+../x86_64-mlnx_msn4410-r0/system_health_monitoring_config.json


### PR DESCRIPTION


Signed-off-by: Kebo Liu <kebol@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
For MSN4410/MSN4600/MSN4700 now they can support to fetch PSU voltage threshold, no need to skip the psu voltage check in system health monitoring, so update the system health monitoring configuration file for these platforms.

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

