### PR TITLE
Support ONIE upgrade for SN2201

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/component.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/component.py
@@ -13,6 +13,7 @@ try:
     import glob
     import tempfile
     import subprocess
+    from sonic_py_common import device_info
     if sys.version_info[0] > 2:
         import configparser
     else:
@@ -113,6 +114,11 @@ class ONIEUpdater(object):
     ONIE_NO_PENDING_UPDATES_ATTR = 'No pending firmware updates present'
 
     ONIE_IMAGE_INFO_COMMAND = '/bin/bash {} -q -i'
+
+    PLATFORM_ALWAYS_SUPPORT_UPGRADE = ['x86_64-nvidia_sn2201-r0']
+
+    def __init__(self):
+        self.platform = device_info.get_platform()
 
     def __mount_onie_fs(self):
         fs_mountpoint = '/mnt/onie-fs'
@@ -312,6 +318,9 @@ class ONIEUpdater(object):
             raise
 
     def is_non_onie_firmware_update_supported(self):
+        if self.platform in self.PLATFORM_ALWAYS_SUPPORT_UPGRADE:
+            return True
+
         current_version = self.get_onie_version()
         _, _, major1, minor1, release1, _ = self.parse_onie_version(current_version)
         version1 = int("{}{}{}".format(major1, minor1, release1))


### PR DESCRIPTION
Do not check ONIE version on SN2201.
In legacy switches, upgrading firmware from ONIE was supported from a certain version
while it is supported from the very beginning on SN2201.
So we do not need to check ONIE version on SN2201

Signed-off-by: Stephen Sun <stephens@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

