### PR TITLE
Support initialization of RJ45 port status

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/sfp_event.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/sfp_event.py
@@ -147,8 +147,7 @@ class sfp_event:
         self.user_channel_p = new_sx_user_channel_t_p()
 
         self.RJ45_port_list = rj45_port_list
-        if rj45_port_list:
-            self.absent_ports_before_init = []
+        self.absent_ports_before_init = []
 
     def initialize(self):
         swid_cnt_p = None
@@ -325,7 +324,16 @@ class sfp_event:
                     # 3. and then the sfp module is removed
                     # 4. sfp_event starts to try fetching the change event
                     # in this case found is increased so that True will be returned
-                    logger.log_info("unknown module state {}, maybe the port suffers two adjacent insertion/removal".format(module_state))
+                    # For RJ45 ports, we will report "unknown" event anyway since it's legal
+                    reported = 0
+                    if self.RJ45_port_list:
+                        for port in port_list:
+                            if port in self.RJ45_port_list:
+                                port_change[port+1] = sfp_state
+                                reported += 1
+
+                    if not reported:
+                        logger.log_info("unknown module state {}, maybe the port suffers two adjacent insertion/removal".format(module_state))
                     found += 1
                     continue
 

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/sfp_event.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/sfp_event.py
@@ -115,6 +115,10 @@ sfp_value_status_dict = {
     SDK_SFP_STATE_DIS: str(SFP.SFP_STATUS_BIT_REMOVED),
 }
 
+# RJ45 ports events definition
+RJ45_UNPLUG_EVENT = '1073741824'
+RJ45_UNKNOWN_EVENT = '2147483648'
+
 # system level event/error
 EVENT_ON_ALL_SFP = '-1'
 SYSTEM_NOT_READY = 'system_not_ready'
@@ -134,13 +138,17 @@ class sfp_event:
     SX_OPEN_TIMEOUT = 5
     SELECT_TIMEOUT = 1
 
-    def __init__(self):
+    def __init__(self, rj45_port_list=None):
         self.swid = 0
         self.handle = None
 
         # Allocate SDK fd and user channel structures
         self.rx_fd_p = new_sx_fd_t_p()
         self.user_channel_p = new_sx_user_channel_t_p()
+
+        self.RJ45_port_list = rj45_port_list
+        if rj45_port_list:
+            self.absent_ports_before_init = []
 
     def initialize(self):
         swid_cnt_p = None
@@ -205,6 +213,30 @@ class sfp_event:
 
             if rc != SX_STATUS_SUCCESS:
                 raise RuntimeError("sx_api_host_ifc_trap_id_register_set failed with rc {}, exiting...".format(rc))
+
+            if self.RJ45_port_list:
+                # Fetch the present state of each RJ45 port.
+                module_id_info_list = new_sx_mgmt_module_id_info_t_arr(1)
+                module_info_list = new_sx_mgmt_phy_module_info_t_arr(1)
+                absent_port_list = []
+
+                for i in self.RJ45_port_list:
+                    module_id_info = sx_mgmt_module_id_info_t()
+                    module_id_info.slot_id = 0
+                    module_id_info.module_id = i
+                    sx_mgmt_module_id_info_t_arr_setitem(module_id_info_list, 0, module_id_info)
+
+                    rc = sx_mgmt_phy_module_info_get(self.handle, module_id_info_list, 1, module_info_list)
+                    assert SX_STATUS_SUCCESS == rc, "sx_mgmt_phy_module_info_get failed, error code {}".format(rc)
+
+                    mod_info = sx_mgmt_phy_module_info_t_arr_getitem(module_info_list, 0)
+                    if  mod_info.module_state.oper_state not in [SX_PORT_MODULE_STATUS_PLUGGED, SX_PORT_MODULE_STATUS_PLUGGED_DISABLED]:
+                        absent_port_list.append(i)
+
+                self.absent_ports_before_init = absent_port_list
+
+                delete_sx_mgmt_module_id_info_t_arr(module_id_info_list)
+                delete_sx_mgmt_phy_module_info_t_arr(module_info_list)
         except Exception as e:
             logger.log_error("sfp_event initialization failed due to {}, exiting...".format(repr(e)))
             if swid_cnt_p is not None:
@@ -254,6 +286,15 @@ class sfp_event:
             to repeat calling it with timeout = 0 in a loop until no new notification read (in this case it returns false).
             by doing so all the notifications in the fd can be retrieved through a single call to get_change_event.
         """
+        if self.absent_ports_before_init:
+            # This is the first time this method is called.
+            # We should return the ports that are not present during initialization
+            for i in self.absent_ports_before_init:
+                error_dict[i + 1] = 'Not present'
+                port_change[i + 1] = RJ45_UNPLUG_EVENT
+            self.absent_ports_before_init = []
+            return True
+
         found = 0
 
         try:
@@ -314,6 +355,32 @@ class sfp_event:
                     if error_description:
                         error_dict[port+1] = error_description
                     found += 1
+
+        if self.RJ45_port_list:
+            # Translate any plugin/plugout event into error dict for RJ45 ports
+            unknown_port = set()
+            unplug_port = set()
+            for index, event in port_change.items():
+                if index in self.RJ45_port_list:
+                    # Remove it from port event
+                    # check if it's unknown event
+                    if event == '0': # Remove event
+                        unplug_port.add(index)
+                    elif event != '1':
+                        unknown_port.add(index)
+            # This is to leverage TRANSCEIVER_STATUS table to represent 'Not present' and 'Unknown' state
+            # The event should satisfies:
+            # - Vendor specific error bit
+            # - Non-blocking bit
+            # Currently, the 2 MSBs are reserved for this since they are most unlikely to be used in the near future
+            for index in unknown_port:
+                # Bit 31 for unknown
+                port_change[index] = RJ45_UNKNOWN_EVENT
+                error_dict[index] = 'Unknown'
+            for index in unplug_port:
+                # Bit 30 for not present
+                port_change[index] = RJ45_UNPLUG_EVENT
+                error_dict[index] = 'Not present'
 
         return found != 0
 

--- a/platform/mellanox/mlnx-platform-api/tests/test_sfp_event.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_sfp_event.py
@@ -31,7 +31,7 @@ class TestSfpEvent(object):
         os.environ["MLNX_PLATFORM_API_UNIT_TESTING"] = "1"
 
     @patch('select.select', MagicMock(return_value=([99], None, None)))
-    def test_check_sfp_status(self):
+    def test_check_sfp_status_xsfp(self):
         from sonic_platform.sfp_event import SDK_SFP_STATE_IN, SDK_SFP_STATE_OUT, SDK_SFP_STATE_ERR
         from sonic_platform.sfp_event import SDK_ERRORS_TO_ERROR_BITS, SDK_ERRORS_TO_DESCRIPTION, SDK_SFP_BLOCKING_ERRORS
 
@@ -59,3 +59,47 @@ class TestSfpEvent(object):
         if description:
             assert 1 in error_dict and error_dict[1] == description
             assert 2 in error_dict and error_dict[2] == description
+
+    @patch('select.select', MagicMock(return_value=([99], None, None)))
+    def test_check_sfp_status_rj45(self):
+        from sonic_platform.sfp_event import sfp_event
+        from sonic_platform.sfp_event import SDK_SFP_STATE_IN, SDK_SFP_STATE_OUT, SDK_SFP_STATE_ERR
+        from sonic_platform.sfp_event import SDK_ERRORS_TO_ERROR_BITS, SDK_ERRORS_TO_DESCRIPTION, SDK_SFP_BLOCKING_ERRORS
+        from sonic_platform.sfp_event import RJ45_UNPLUG_EVENT, RJ45_UNKNOWN_EVENT
+
+        # Verify absent ports before initialization
+        event = sfp_event([0, 1, 2, 3])
+        event.absent_ports_before_init = [0,1]
+        port_change = {}
+        error_dict = {}
+        found = event.check_sfp_status(port_change, error_dict, 0)
+        assert found
+        assert port_change == {1: RJ45_UNPLUG_EVENT, 2: RJ45_UNPLUG_EVENT}
+        assert error_dict == {1: 'Not present', 2: 'Not present'}
+
+        # Unplug event
+        event.on_pmpe = MagicMock(return_value=(True, [2], SDK_SFP_STATE_OUT, None))
+        port_change.clear()
+        error_dict.clear()
+        found = event.check_sfp_status(port_change, error_dict, 0)
+        assert found
+        assert port_change == {3: RJ45_UNPLUG_EVENT}
+        assert error_dict == {3: 'Not present'}
+
+        # Plug event
+        event.on_pmpe = MagicMock(return_value=(True, [2], SDK_SFP_STATE_IN, None))
+        port_change.clear()
+        error_dict.clear()
+        found = event.check_sfp_status(port_change, error_dict, 0)
+        assert found
+        assert port_change == {3: str(SDK_SFP_STATE_IN)}
+        assert error_dict == {}
+
+        # Unknown event
+        event.on_pmpe = MagicMock(return_value=(True, [2], -1, None))
+        port_change.clear()
+        error_dict.clear()
+        found = event.check_sfp_status(port_change, error_dict, 0)
+        assert found
+        assert port_change == {3: RJ45_UNKNOWN_EVENT}
+        assert error_dict == {3: 'Unknown'}

--- a/platform/mellanox/mlnx-platform-api/tests/test_sfp_event.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_sfp_event.py
@@ -63,8 +63,7 @@ class TestSfpEvent(object):
     @patch('select.select', MagicMock(return_value=([99], None, None)))
     def test_check_sfp_status_rj45(self):
         from sonic_platform.sfp_event import sfp_event
-        from sonic_platform.sfp_event import SDK_SFP_STATE_IN, SDK_SFP_STATE_OUT, SDK_SFP_STATE_ERR
-        from sonic_platform.sfp_event import SDK_ERRORS_TO_ERROR_BITS, SDK_ERRORS_TO_DESCRIPTION, SDK_SFP_BLOCKING_ERRORS
+        from sonic_platform.sfp_event import SDK_SFP_STATE_IN, SDK_SFP_STATE_OUT
         from sonic_platform.sfp_event import RJ45_UNPLUG_EVENT, RJ45_UNKNOWN_EVENT
 
         # Verify absent ports before initialization


### PR DESCRIPTION
- Hide the logic to convert port_change to error_dict inside sfp_event
- In case there are some RJ45 ports are down (not present),
  report them as sfp_event during the first round of get_change_event
  This is because SDK/FW will never report port change occurred before init
  We must make compensation for it in platform API

Signed-off-by: Stephen Sun <stephens@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

