### PR TITLE
Fix review comments: do a mock in unit test and make extract_RJ45_ports_index_return []

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
@@ -532,8 +532,9 @@ class Chassis(ChassisBase):
             self._component_list.append(ComponentSSD())
             # Upgrading BIOS is not supported on SN2201
             if DeviceDataManager.get_platform_name() not in ['x86_64-nvidia_sn2201-r0']:
-                logger.log_notice("Updating BIOS is not supported on SN2201")
                 self._component_list.append(ComponentBIOS())
+            else:
+                logger.log_notice("Updating BIOS is not supported on SN2201")
             self._component_list.extend(ComponentCPLD.get_component_list())
 
     def get_num_components(self):

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
@@ -111,11 +111,7 @@ class Chassis(ChassisBase):
         self.reboot_cause_initialized = False
 
         # Build the RJ45 port list from platform.json and hwsku.json
-        try:
-            if os.environ["PLATFORM_API_UNIT_TESTING"] == "1":
-                self.RJ45_port_list = None
-        except KeyError:
-            self.RJ45_port_list = extract_RJ45_ports_index()
+        self.RJ45_port_list = extract_RJ45_ports_index()
 
         logger.log_info("Chassis loaded successfully")
 

--- a/platform/mellanox/mlnx-platform-api/tests/test_chassis.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_chassis.py
@@ -28,9 +28,11 @@ test_path = os.path.dirname(os.path.abspath(__file__))
 modules_path = os.path.dirname(test_path)
 sys.path.insert(0, modules_path)
 
+import sonic_platform.chassis
 from sonic_platform.chassis import Chassis
 from sonic_platform.device_data import DeviceDataManager
 
+sonic_platform.chassis.extract_RJ45_ports_index = mock.MagicMock(return_value=[])
 
 class TestChassis:
     """Test class to test chassis.py. The test cases covers:

--- a/platform/mellanox/mlnx-platform-api/tests/test_eeprom.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_eeprom.py
@@ -30,11 +30,11 @@ sys.path.insert(0, modules_path)
 from sonic_platform.chassis import Chassis
 from sonic_platform.eeprom import Eeprom, EepromContentVisitor
 
-
 class TestEeprom:
     @patch('os.path.exists', MagicMock(return_value=True))
     @patch('os.path.islink', MagicMock(return_value=True))
     @patch('sonic_platform.eeprom.Eeprom.get_system_eeprom_info')
+    @patch('sonic_platform.chassis.extract_RJ45_ports_index', MagicMock(return_value=[]))
     def test_chassis_eeprom(self, mock_eeprom_info):
         mock_eeprom_info.return_value = {
             hex(Eeprom._TLV_CODE_PRODUCT_NAME): 'MSN3420',
@@ -102,7 +102,3 @@ class TestEeprom:
         v.visit_tlv('tlv3', Eeprom._TLV_CODE_VENDOR_EXT, 4, 'ext2')
         assert content[hex(Eeprom._TLV_CODE_PRODUCT_NAME)] == 'MSN3420'
         assert content[hex(Eeprom._TLV_CODE_VENDOR_EXT)] == ['ext1', 'ext2']
-
-
-
-        

--- a/platform/mellanox/mlnx-platform-api/tests/test_led.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_led.py
@@ -35,6 +35,7 @@ from sonic_platform.psu import FixedPsu, Psu
 
 class TestLed:
     @mock.patch('sonic_platform.led.Led._wait_files_ready', mock.MagicMock(return_value=True))
+    @mock.patch('sonic_platform.chassis.extract_RJ45_ports_index', mock.MagicMock(return_value=True))
     def test_chassis_led(self):
         chassis = Chassis()
         assert chassis._led is None

--- a/platform/mellanox/mlnx-platform-api/tests/test_module.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_module.py
@@ -26,6 +26,7 @@ test_path = os.path.dirname(os.path.abspath(__file__))
 modules_path = os.path.dirname(test_path)
 sys.path.insert(0, modules_path)
 
+import sonic_platform.chassis
 from sonic_platform import utils
 from sonic_platform.chassis import ModularChassis
 from sonic_platform.device_data import DeviceDataManager
@@ -37,6 +38,7 @@ class TestModule:
     def setup_class(cls):
         DeviceDataManager.get_linecard_sfp_count = mock.MagicMock(return_value=2)
         DeviceDataManager.get_linecard_count = mock.MagicMock(return_value=2)
+        sonic_platform.chassis.extract_RJ45_ports_index = mock.MagicMock(return_value=[])
 
     def test_chassis_get_num_sfp(self):
         chassis = ModularChassis()

--- a/platform/mellanox/mlnx-platform-api/tests/test_sfp.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_sfp.py
@@ -52,6 +52,7 @@ class TestSfp:
     @mock.patch('sonic_platform.sfp.SFP._read_eeprom_specific_bytes', mock.MagicMock(return_value=None))
     @mock.patch('sonic_platform.sfp.SFP._get_error_code')
     @mock.patch('sonic_platform.chassis.Chassis.get_num_sfps', mock.MagicMock(return_value=2))
+    @mock.patch('sonic_platform.chassis.extract_RJ45_ports_index', mock.MagicMock(return_value=[]))
     def test_sfp_get_error_status(self, mock_get_error_code):
         chassis = Chassis()
 

--- a/platform/mellanox/mlnx-platform-api/tests/test_thermal.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_thermal.py
@@ -28,9 +28,11 @@ test_path = os.path.dirname(os.path.abspath(__file__))
 modules_path = os.path.dirname(test_path)
 sys.path.insert(0, modules_path)
 
+import sonic_platform.chassis
 from sonic_platform.chassis import Chassis
 from sonic_platform.device_data import DeviceDataManager
 
+sonic_platform.chassis.extract_RJ45_ports_index = mock.MagicMock(return_value=[])
 
 class TestThermal:
     @mock.patch('os.path.exists', mock.MagicMock(return_value=True))


### PR DESCRIPTION


Signed-off-by: Stephen Sun <stephens@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

