### PR TITLE
[Mellanox] Add flag 'skip_xcvrd_cmis_mgr' to skip CMIS task on Mellanox platform

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2700-r0/pmon_daemon_control.json
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/pmon_daemon_control.json
@@ -1,6 +1,7 @@
 {
     "skip_ledd": true,
     "skip_fancontrol": true,
-    "delay_xcvrd": true
+    "delay_xcvrd": true,
+    "skip_xcvrd_cmis_mgr": true
 }
 


### PR DESCRIPTION
Signed-off-by: Kebo Liu <kebol@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The community introduced a CMIS cable sub-task to the XCVRD daemon to take care of the CMIS cable initializing work, which is not required on the Mellanox platform due to the different ways of managing the CMIS cable. Detail info please check PR https://github.com/sonic-net/SONiC/pull/971

#### How I did it

Set flag 'skip_xcvrd_cmis_mgr' to true in  pmon_daemon_control.json for all the Mellanox platforms.

#### How to verify it

Check CMIS task is not started on Mellanox platforms.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

