### PR TITLE
[yang]support new interface types CR8/SR8/KR8/LR8 which are brougnt by SAI V.1.10.2

### DIFF
--- a/src/sonic-yang-models/yang-templates/sonic-types.yang.j2
+++ b/src/sonic-yang-models/yang-templates/sonic-types.yang.j2
@@ -136,13 +136,17 @@ module sonic-types {
             enum CR;
             enum CR2;
             enum CR4;
+            enum CR8;
             enum SR;
             enum SR2;
             enum SR4;
+            enum SR8;
             enum LR;
             enum LR4;
+            enum LR8;
             enum KR;
             enum KR4;
+            enum KR8;
             enum CAUI;
             enum GMII;
             enum SFI;


### PR DESCRIPTION
Signed-off-by: Kebo Liu <kebol@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

With SAI V.1.10.2, new interface types CR8/SR8/KR8/LR8 have been introduced, we should also support them from the CLI configuration.

#### How I did it

Add new enum for the new interface types

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

