### PR TITLE
[Mellanox] Update SN2201 sai profile and platform reboot script

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2700-r0/platform_reboot
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/platform_reboot
@@ -5,7 +5,7 @@ declare -r EXIT_ERROR="1"
 
 declare -r PENDING_COMPONENT_FW="/usr/bin/install-pending-fw.py"
 declare -r FW_UPGRADE_SCRIPT="/usr/bin/mlnx-fw-upgrade.sh"
-declare -r SYSFS_PWR_CYCLE="/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/pwr_cycle"
+declare -r SYSFS_PWR_CYCLE="/var/run/hw-management/system/pwr_cycle"
 
 FORCE_REBOOT="no"
 
@@ -24,8 +24,6 @@ function SafePwrCycle() {
     sync ; sync
     umount -fa > /dev/null 2&>1
     echo 1 > $SYSFS_PWR_CYCLE
-    sleep 3
-    echo 0 > $SYSFS_PWR_CYCLE
 }
 
 ParseArguments "$@"

--- a/device/mellanox/x86_64-nvidia_sn2201-r0/ACS-SN2201/sai_2201.xml
+++ b/device/mellanox/x86_64-nvidia_sn2201-r0/ACS-SN2201/sai_2201.xml
@@ -1,4 +1,21 @@
 <?xml version="1.0"?>
+<!--
+  Copyright (c) 2019-2021 NVIDIA CORPORATION & AFFILIATES.
+  Apache-2.0
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
 <root>
     <platform_info type="2201">
 

--- a/device/mellanox/x86_64-nvidia_sn2201-r0/ACS-SN2201/sai_2201.xml
+++ b/device/mellanox/x86_64-nvidia_sn2201-r0/ACS-SN2201/sai_2201.xml
@@ -1,21 +1,4 @@
 <?xml version="1.0"?>
-<!--
-  Copyright (c) 2019-2021 NVIDIA CORPORATION & AFFILIATES.
-  Apache-2.0
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-  http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
--->
-
 <root>
     <platform_info type="2201">
 
@@ -36,337 +19,337 @@
                 <module>0</module>
                 <!-- 0 none, 1=2, 2=4, 3=2,4 -->
                 <breakout-modes>0</breakout-modes>
-                <!-- (BITMASK) 3 - 1Gb, 28700 - 10Gb , 939524096 - 25Gb , 98368 - 40Gb , 3221225472 - 50Gb , 11534336 - 100Gb-->
-                <port-speed>3</port-speed>
+                <!-- (BITMASK) 3 - 1Gb, 28700 - 10Gb , 939524096 - 25Gb , 98368 - 40Gb , 3221225472 - 50Gb , 11534336 - 100Gb, 1024 - 10MB_T, 2048 - 100MB_TX, 131072 - 1000MB_T  -->
+                <port-speed>131072</port-speed>
             </port-info>
             <port-info>
                 <local-port>62</local-port>
                 <width>1</width>
                 <module>1</module>
                 <breakout-modes>0</breakout-modes>
-                <port-speed>3</port-speed>
+                <port-speed>131072</port-speed>
             </port-info>
             <port-info>
                 <local-port>63</local-port>
                 <width>1</width>
                 <module>2</module>
                 <breakout-modes>0</breakout-modes>
-                <port-speed>3</port-speed>
+                <port-speed>131072</port-speed>
             </port-info>
             <port-info>
                 <local-port>64</local-port>
                 <width>1</width>
                 <module>3</module>
                 <breakout-modes>0</breakout-modes>
-                <port-speed>3</port-speed>
+                <port-speed>131072</port-speed>
             </port-info>
             <port-info>
                 <local-port>57</local-port>
                 <width>1</width>
                 <module>4</module>
                 <breakout-modes>0</breakout-modes>
-                <port-speed>3</port-speed>
+                <port-speed>131072</port-speed>
             </port-info>
             <port-info>
                 <local-port>58</local-port>
                 <width>1</width>
                 <module>5</module>
                 <breakout-modes>0</breakout-modes>
-                <port-speed>3</port-speed>
+                <port-speed>131072</port-speed>
             </port-info>
             <port-info>
                 <local-port>59</local-port>
                 <width>1</width>
                 <module>6</module>
                 <breakout-modes>0</breakout-modes>
-                <port-speed>3</port-speed>
+                <port-speed>131072</port-speed>
             </port-info>
             <port-info>
                 <local-port>60</local-port>
                 <width>1</width>
                 <module>7</module>
                 <breakout-modes>0</breakout-modes>
-                <port-speed>3</port-speed>
+                <port-speed>131072</port-speed>
             </port-info>
             <port-info>
                 <local-port>53</local-port>
                 <width>1</width>
                 <module>8</module>
                 <breakout-modes>0</breakout-modes>
-                <port-speed>3</port-speed>
+                <port-speed>131072</port-speed>
             </port-info>
             <port-info>
                 <local-port>54</local-port>
                 <width>1</width>
                 <module>9</module>
                 <breakout-modes>0</breakout-modes>
-                <port-speed>3</port-speed>
+                <port-speed>131072</port-speed>
             </port-info>
             <port-info>
                 <local-port>55</local-port>
                 <width>1</width>
                 <module>10</module>
                 <breakout-modes>0</breakout-modes>
-                <port-speed>3</port-speed>
+                <port-speed>131072</port-speed>
             </port-info>
             <port-info>
                 <local-port>56</local-port>
                 <width>1</width>
                 <module>11</module>
                 <breakout-modes>0</breakout-modes>
-                <port-speed>3</port-speed>
+                <port-speed>131072</port-speed>
             </port-info>
             <port-info>
                 <local-port>49</local-port>
                 <width>1</width>
                 <module>12</module>
                 <breakout-modes>0</breakout-modes>
-                <port-speed>3</port-speed>
+                <port-speed>131072</port-speed>
             </port-info>
             <port-info>
                 <local-port>50</local-port>
                 <width>1</width>
                 <module>13</module>
                 <breakout-modes>0</breakout-modes>
-                <port-speed>3</port-speed>
+                <port-speed>131072</port-speed>
             </port-info>
             <port-info>
                 <local-port>51</local-port>
                 <width>1</width>
                 <module>14</module>
                 <breakout-modes>0</breakout-modes>
-                <port-speed>3</port-speed>
+                <port-speed>131072</port-speed>
             </port-info>
             <port-info>
                 <local-port>52</local-port>
                 <width>1</width>
                 <module>15</module>
                 <breakout-modes>0</breakout-modes>
-                <port-speed>3</port-speed>
+                <port-speed>131072</port-speed>
             </port-info>
             <port-info>
                 <local-port>45</local-port>
                 <width>1</width>
                 <module>16</module>
                 <breakout-modes>0</breakout-modes>
-                <port-speed>3</port-speed>
+                <port-speed>131072</port-speed>
             </port-info>
             <port-info>
                 <local-port>46</local-port>
                 <width>1</width>
                 <module>17</module>
                 <breakout-modes>0</breakout-modes>
-                <port-speed>3</port-speed>
+                <port-speed>131072</port-speed>
             </port-info>
             <port-info>
                 <local-port>47</local-port>
                 <width>1</width>
                 <module>18</module>
                 <breakout-modes>0</breakout-modes>
-                <port-speed>3</port-speed>
+                <port-speed>131072</port-speed>
             </port-info>
             <port-info>
                 <local-port>48</local-port>
                 <width>1</width>
                 <module>19</module>
                 <breakout-modes>0</breakout-modes>
-                <port-speed>3</port-speed>
+                <port-speed>131072</port-speed>
             </port-info>
             <port-info>
                 <local-port>41</local-port>
                 <width>1</width>
                 <module>20</module>
                 <breakout-modes>0</breakout-modes>
-                <port-speed>3</port-speed>
+                <port-speed>131072</port-speed>
             </port-info>
             <port-info>
                 <local-port>42</local-port>
                 <width>1</width>
                 <module>21</module>
                 <breakout-modes>0</breakout-modes>
-                <port-speed>3</port-speed>
+                <port-speed>131072</port-speed>
             </port-info>
             <port-info>
                 <local-port>43</local-port>
                 <width>1</width>
                 <module>22</module>
                 <breakout-modes>0</breakout-modes>
-                <port-speed>3</port-speed>
+                <port-speed>131072</port-speed>
             </port-info>
             <port-info>
                 <local-port>44</local-port>
                 <width>1</width>
                 <module>23</module>
                 <breakout-modes>0</breakout-modes>
-                <port-speed>3</port-speed>
+                <port-speed>131072</port-speed>
             </port-info>
             <port-info>
                 <local-port>37</local-port>
                 <width>1</width>
                 <module>24</module>
                 <breakout-modes>0</breakout-modes>
-                <port-speed>3</port-speed>
+                <port-speed>131072</port-speed>
             </port-info>
             <port-info>
                 <local-port>38</local-port>
                 <width>1</width>
                 <module>25</module>
                 <breakout-modes>0</breakout-modes>
-                <port-speed>3</port-speed>
+                <port-speed>131072</port-speed>
             </port-info>
             <port-info>
                 <local-port>39</local-port>
                 <width>1</width>
                 <module>26</module>
                 <breakout-modes>0</breakout-modes>
-                <port-speed>3</port-speed>
+                <port-speed>131072</port-speed>
             </port-info>
             <port-info>
                 <local-port>40</local-port>
                 <width>1</width>
                 <module>27</module>
                 <breakout-modes>0</breakout-modes>
-                <port-speed>3</port-speed>
+                <port-speed>131072</port-speed>
             </port-info>
             <port-info>
                 <local-port>33</local-port>
                 <width>1</width>
                 <module>28</module>
                 <breakout-modes>0</breakout-modes>
-                <port-speed>3</port-speed>
+                <port-speed>131072</port-speed>
             </port-info>
             <port-info>
                 <local-port>34</local-port>
                 <width>1</width>
                 <module>29</module>
                 <breakout-modes>0</breakout-modes>
-                <port-speed>3</port-speed>
+                <port-speed>131072</port-speed>
             </port-info>
             <port-info>
                 <local-port>35</local-port>
                 <width>1</width>
                 <module>30</module>
                 <breakout-modes>0</breakout-modes>
-                <port-speed>3</port-speed>
+                <port-speed>131072</port-speed>
             </port-info>
             <port-info>
                 <local-port>36</local-port>
                 <width>1</width>
                 <module>31</module>
                 <breakout-modes>0</breakout-modes>
-                <port-speed>3</port-speed>
+                <port-speed>131072</port-speed>
             </port-info>
             <port-info>
                 <local-port>1</local-port>
                 <width>1</width>
                 <module>32</module>
                 <breakout-modes>0</breakout-modes>
-                <port-speed>3</port-speed>
+                <port-speed>131072</port-speed>
             </port-info>
             <port-info>
                 <local-port>2</local-port>
                 <width>1</width>
                 <module>33</module>
                 <breakout-modes>0</breakout-modes>
-                <port-speed>3</port-speed>
+                <port-speed>131072</port-speed>
             </port-info>
             <port-info>
                 <local-port>3</local-port>
                 <width>1</width>
                 <module>34</module>
                 <breakout-modes>0</breakout-modes>
-                <port-speed>3</port-speed>
+                <port-speed>131072</port-speed>
             </port-info>
             <port-info>
                 <local-port>4</local-port>
                 <width>1</width>
                 <module>35</module>
                 <breakout-modes>0</breakout-modes>
-                <port-speed>3</port-speed>
-            </port-info>
-            <port-info>
-                <local-port>5</local-port>
-                <width>1</width>
-                <module>36</module>
-                <breakout-modes>0</breakout-modes>
-                <port-speed>3</port-speed>
-            </port-info>
-            <port-info>
-                <local-port>6</local-port>
-                <width>1</width>
-                <module>37</module>
-                <breakout-modes>0</breakout-modes>
-                <port-speed>3</port-speed>
-            </port-info>
-            <port-info>
-                <local-port>17</local-port>
-                <width>1</width>
-                <module>38</module>
-                <breakout-modes>0</breakout-modes>
-                <port-speed>3</port-speed>
-            </port-info>
-            <port-info>
-                <local-port>18</local-port>
-                <width>1</width>
-                <module>39</module>
-                <breakout-modes>0</breakout-modes>
-                <port-speed>3</port-speed>
-            </port-info>
-            <port-info>
-                <local-port>19</local-port>
-                <width>1</width>
-                <module>40</module>
-                <breakout-modes>0</breakout-modes>
-                <port-speed>3</port-speed>
-            </port-info>
-            <port-info>
-                <local-port>20</local-port>
-                <width>1</width>
-                <module>41</module>
-                <breakout-modes>0</breakout-modes>
-                <port-speed>3</port-speed>
+                <port-speed>131072</port-speed>
             </port-info>
             <port-info>
                 <local-port>21</local-port>
                 <width>1</width>
-                <module>42</module>
+                <module>36</module>
                 <breakout-modes>0</breakout-modes>
-                <port-speed>3</port-speed>
+                <port-speed>131072</port-speed>
             </port-info>
             <port-info>
                 <local-port>22</local-port>
                 <width>1</width>
-                <module>43</module>
+                <module>37</module>
                 <breakout-modes>0</breakout-modes>
-                <port-speed>3</port-speed>
+                <port-speed>131072</port-speed>
             </port-info>
             <port-info>
                 <local-port>23</local-port>
                 <width>1</width>
-                <module>44</module>
+                <module>38</module>
                 <breakout-modes>0</breakout-modes>
-                <port-speed>3</port-speed>
+                <port-speed>131072</port-speed>
             </port-info>
             <port-info>
                 <local-port>24</local-port>
                 <width>1</width>
-                <module>45</module>
+                <module>39</module>
                 <breakout-modes>0</breakout-modes>
-                <port-speed>3</port-speed>
+                <port-speed>131072</port-speed>
             </port-info>
             <port-info>
                 <local-port>25</local-port>
                 <width>1</width>
-                <module>46</module>
+                <module>40</module>
                 <breakout-modes>0</breakout-modes>
-                <port-speed>3</port-speed>
+                <port-speed>131072</port-speed>
             </port-info>
             <port-info>
                 <local-port>26</local-port>
                 <width>1</width>
+                <module>41</module>
+                <breakout-modes>0</breakout-modes>
+                <port-speed>131072</port-speed>
+            </port-info>
+            <port-info>
+                <local-port>27</local-port>
+                <width>1</width>
+                <module>42</module>
+                <breakout-modes>0</breakout-modes>
+                <port-speed>131072</port-speed>
+            </port-info>
+            <port-info>
+                <local-port>28</local-port>
+                <width>1</width>
+                <module>43</module>
+                <breakout-modes>0</breakout-modes>
+                <port-speed>131072</port-speed>
+            </port-info>
+            <port-info>
+                <local-port>29</local-port>
+                <width>1</width>
+                <module>44</module>
+                <breakout-modes>0</breakout-modes>
+                <port-speed>131072</port-speed>
+            </port-info>
+            <port-info>
+                <local-port>30</local-port>
+                <width>1</width>
+                <module>45</module>
+                <breakout-modes>0</breakout-modes>
+                <port-speed>131072</port-speed>
+            </port-info>
+            <port-info>
+                <local-port>31</local-port>
+                <width>1</width>
+                <module>46</module>
+                <breakout-modes>0</breakout-modes>
+                <port-speed>131072</port-speed>
+            </port-info>
+            <port-info>
+                <local-port>32</local-port>
+                <width>1</width>
                 <module>47</module>
                 <breakout-modes>0</breakout-modes>
-                <port-speed>3</port-speed>
+                <port-speed>131072</port-speed>
             </port-info>
             <port-info>
                 <local-port>9</local-port>
@@ -376,21 +359,21 @@
                 <port-speed>11534336</port-speed>
             </port-info>
             <port-info>
-                <local-port>7</local-port>
+                <local-port>5</local-port>
                 <width>4</width>
                 <module>49</module>
                 <breakout-modes>3</breakout-modes>
                 <port-speed>11534336</port-speed>
             </port-info>
             <port-info>
-                <local-port>13</local-port>
+                <local-port>17</local-port>
                 <width>4</width>
                 <module>50</module>
                 <breakout-modes>3</breakout-modes>
                 <port-speed>11534336</port-speed>
             </port-info>
             <port-info>
-                <local-port>11</local-port>
+                <local-port>13</local-port>
                 <width>4</width>
                 <module>51</module>
                 <breakout-modes>3</breakout-modes>


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
1. SN2201 sai profile needs to be updated according to the latest hardware.
2. In the reboot script, need to use the common symbol link of the power_cycle sysfs instead of directly accessing it due to SN2201 sysfs is different than other platforms.

#### How I did it
1. Replace the Sn2201 sai profile with the latest one.
2. In the platform_reboot script, replace the direct sysfs path with the symbol link path.

#### How to verify it
perform reboot on all the Nvidia platforms, and check all can be rebooted successfully.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

