### PR TITLE
[202111]Add retry when SFP object is not initialized correctly due to eeprom read failure

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
@@ -483,6 +483,7 @@ class SFP(SfpBase):
                 self._sfp_capability.qsfp_page3_available = dom_status_indicator['data']['FlatMem']['value'] == 'Off'
                 self._sfp_capability.dom_detect_finished = True
             else:
+                logger.log_warning("SFP {}: Dom capabilty parsing is failed due to eeprom read fail, will re-try next time.".format(self.index))
                 self._sfp_capability.dom_supported = False
                 self._sfp_capability.dom_temp_supported = False
                 self._sfp_capability.dom_volt_supported = False
@@ -531,6 +532,7 @@ class SFP(SfpBase):
                 self._sfp_capability.dom_thresholds_supported = False
                 self._sfp_capability.dom_rx_tx_power_bias_supported = False
                 self._sfp_capability.dom_detect_finished = False
+                logger.log_warning("SFP {}: Dom capabilty parsing is failed due to eeprom read fail, will re-try next time.".format(self.index))
 
         elif self.sfp_type == SFP_TYPE:
             sfpi_obj = sff8472InterfaceId()
@@ -566,6 +568,7 @@ class SFP(SfpBase):
             self._sfp_capability.dom_rx_power_supported = False
             self._sfp_capability.dom_tx_power_supported = False
             self._sfp_capability.dom_detect_finished = False
+            logger.log_warning("SFP {}: Dom capabilty parsing is failed due to sfp type is not one of the supported ones, will re-try next time.".format(self.index))
 
     @property
     @utils.pre_initialize(_dom_capability_detect)
@@ -924,6 +927,7 @@ class SFP(SfpBase):
                 return None
         else:
             # None of any supported SFP type, could be SFP object not correctly initialized.
+            logger.log_warning("SFP {}: type is not one the supported type, or SFP object initialization is not finished yet.".format(self.index))
             return None
 
         if self.sfp_type != QSFP_DD_TYPE:

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
@@ -369,7 +369,8 @@ class SfpCapability:
         self.calibration = 0
         self.qsfp_page3_available = False
         self.second_application_list = False
-        
+        self.dom_detect_finished = False
+
 
 class SFP(SfpBase):
     """Platform-specific SFP class"""
@@ -437,7 +438,7 @@ class SFP(SfpBase):
             return self._sfp_type
 
     def _dom_capability_detect(self):
-        if self._sfp_capability:
+        if self._sfp_capability and self._sfp_capability.dom_detect_finished:
             return
 
         self._sfp_capability = SfpCapability()
@@ -456,8 +457,9 @@ class SFP(SfpBase):
             # need to add more code for determining the capability and version compliance
             # in SFF-8636 dom capability definitions evolving with the versions.
             qsfp_dom_capability_raw = self._read_eeprom_specific_bytes((offset + XCVR_DOM_CAPABILITY_OFFSET), XCVR_DOM_CAPABILITY_WIDTH)
-            if qsfp_dom_capability_raw is not None:
-                qsfp_version_compliance_raw = self._read_eeprom_specific_bytes(QSFP_VERSION_COMPLIANCE_OFFSET, QSFP_VERSION_COMPLIANCE_WIDTH)
+            qsfp_version_compliance_raw = self._read_eeprom_specific_bytes(QSFP_VERSION_COMPLIANCE_OFFSET, QSFP_VERSION_COMPLIANCE_WIDTH)
+            qsfp_option_value_raw = self._read_eeprom_specific_bytes(QSFP_OPTION_VALUE_OFFSET, QSFP_OPTION_VALUE_WIDTH)
+            if None not in (qsfp_dom_capability_raw, qsfp_version_compliance_raw, qsfp_option_value_raw):
                 qsfp_version_compliance = int(qsfp_version_compliance_raw[0], 16)
                 dom_capability = sfpi_obj.parse_dom_capability(qsfp_dom_capability_raw, 0)
                 if qsfp_version_compliance >= 0x08:
@@ -475,12 +477,12 @@ class SFP(SfpBase):
                 sfpd_obj = sff8436Dom()
                 if sfpd_obj is None:
                     return None
-                qsfp_option_value_raw = self._read_eeprom_specific_bytes(QSFP_OPTION_VALUE_OFFSET, QSFP_OPTION_VALUE_WIDTH)
-                if qsfp_option_value_raw is not None:
-                    optional_capability = sfpd_obj.parse_option_params(qsfp_option_value_raw, 0)
-                    self._sfp_capability.dom_tx_disable_supported = optional_capability['data']['TxDisable']['value'] == 'On'
+
+                optional_capability = sfpd_obj.parse_option_params(qsfp_option_value_raw, 0)
+                self._sfp_capability.dom_tx_disable_supported = optional_capability['data']['TxDisable']['value'] == 'On'
                 dom_status_indicator = sfpd_obj.parse_dom_status_indicator(qsfp_version_compliance_raw, 1)
                 self._sfp_capability.qsfp_page3_available = dom_status_indicator['data']['FlatMem']['value'] == 'Off'
+                self._sfp_capability.dom_detect_finished = True
             else:
                 self._sfp_capability.dom_supported = False
                 self._sfp_capability.dom_temp_supported = False
@@ -489,6 +491,7 @@ class SFP(SfpBase):
                 self._sfp_capability.dom_tx_power_supported = False
                 self._sfp_capability.calibration = 0
                 self._sfp_capability.qsfp_page3_available = False
+                self._sfp_capability.dom_detect_finished = False
 
         elif self.sfp_type == QSFP_DD_TYPE:
             sfpi_obj = qsfp_dd_InterfaceId()
@@ -518,6 +521,7 @@ class SFP(SfpBase):
                     self._sfp_capability.dom_tx_bias_power_supported = False
                     self._sfp_capability.dom_thresholds_supported = False
                     self._sfp_capability.dom_rx_tx_power_bias_supported = False
+                self._sfp_capability.dom_detect_finished = True
             else:
                 self._sfp_capability.dom_supported = False
                 self._sfp_capability.dom_temp_supported = False
@@ -527,6 +531,7 @@ class SFP(SfpBase):
                 self._sfp_capability.dom_tx_bias_power_supported = False
                 self._sfp_capability.dom_thresholds_supported = False
                 self._sfp_capability.dom_rx_tx_power_bias_supported = False
+                self._sfp_capability.dom_detect_finished = False
 
         elif self.sfp_type == SFP_TYPE:
             sfpi_obj = sff8472InterfaceId()
@@ -554,12 +559,14 @@ class SFP(SfpBase):
                     self._sfp_capability.dom_tx_power_supported = False
                     self._sfp_capability.calibration = 0
                 self._sfp_capability.dom_tx_disable_supported = (int(sfp_dom_capability_raw[1], 16) & 0x40 != 0)
+                self._sfp_capability.dom_detect_finished = True
         else:
             self._sfp_capability.dom_supported = False
             self._sfp_capability.dom_temp_supported = False
             self._sfp_capability.dom_volt_supported = False
             self._sfp_capability.dom_rx_power_supported = False
             self._sfp_capability.dom_tx_power_supported = False
+            self._sfp_capability.dom_detect_finished = True
 
     @property
     @utils.pre_initialize(_dom_capability_detect)

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
@@ -565,7 +565,7 @@ class SFP(SfpBase):
             self._sfp_capability.dom_volt_supported = False
             self._sfp_capability.dom_rx_power_supported = False
             self._sfp_capability.dom_tx_power_supported = False
-            self._sfp_capability.dom_detect_finished = True
+            self._sfp_capability.dom_detect_finished = False
 
     @property
     @utils.pre_initialize(_dom_capability_detect)


### PR DESCRIPTION
Signed-off-by: Kebo Liu <kebol@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

