### PR TITLE
[202012] [Mellanox] Add more sensor conf file for new version of MSN3700/3700C/4600C platforms

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn3700-r0/get_sensors_conf_path
+++ b/device/mellanox/x86_64-mlnx_msn3700-r0/get_sensors_conf_path
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+HW_RESPIN_VERSION="/var/run/hw-management/system/config3"
+SENSORS_CONF_FILE="/usr/share/sonic/platform/sensors.conf"
+SENSORS_RESPIN_CONF_FILE="/usr/share/sonic/platform/sensors_respin.conf"
+
+function get_sensor_conf_path() {
+    local _HW_RESPIN_VERSION="0"
+    if [[ -e $HW_RESPIN_VERSION ]]; then
+        _HW_RESPIN_VERSION=$(cat $HW_RESPIN_VERSION 2>&1)
+        if [[ "$_HW_RESPIN_VERSION" == "1" ]]; then
+            if [[ -e $SENSORS_RESPIN_CONF_FILE ]]; then
+                echo $SENSORS_RESPIN_CONF_FILE
+                return
+            fi
+        fi
+    fi
+    echo $SENSORS_CONF_FILE
+}
+
+get_sensor_conf_path

--- a/device/mellanox/x86_64-mlnx_msn3700-r0/sensors_respin.conf
+++ b/device/mellanox/x86_64-mlnx_msn3700-r0/sensors_respin.conf
@@ -1,8 +1,19 @@
-###################################################################################
-## Copyright (c) 2019 - 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-#
-# Platform specific sensors config for SN3700
-###################################################################################
+##
+## Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES.
+## Apache-2.0
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##
 
 # Temperature sensors
 bus "i2c-2" "i2c-1-mux (chan_id 1)"

--- a/device/mellanox/x86_64-mlnx_msn3700-r0/sensors_respin.conf
+++ b/device/mellanox/x86_64-mlnx_msn3700-r0/sensors_respin.conf
@@ -1,0 +1,176 @@
+###################################################################################
+## Copyright (c) 2019 - 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Platform specific sensors config for SN3700
+###################################################################################
+
+# Temperature sensors
+bus "i2c-2" "i2c-1-mux (chan_id 1)"
+    chip "mlxsw-i2c-*-48"
+        label temp1 "Ambient ASIC Temp"
+
+bus "i2c-7" "i2c-1-mux (chan_id 6)"
+    chip "tmp102-i2c-*-49"
+        label temp1 "Ambient Fan Side Temp (air intake)"
+    chip "tmp102-i2c-*-4a"
+        label temp1 "Ambient Port Side Temp (air exhaust)"
+
+bus "i2c-15" "i2c-1-mux (chan_id 6)"
+    chip "tmp102-i2c-15-49"
+        label temp1 "Ambient COMEX Temp"
+
+# Power controllers
+bus "i2c-5" "i2c-1-mux (chan_id 4)"
+    chip "tps53679-i2c-*-70"
+        label in1 "PMIC-1 PSU 12V Rail (in1)"
+        label in2 "PMIC-1 PSU 12V Rail (in2)"
+        label in3 "PMIC-1 ASIC 0.8V VCORE Rail (out)"
+        label in4 "PMIC-1 ASIC 1.2V Rail (out)"
+        label temp1 "PMIC-1 Temp 1"
+        label temp2 "PMIC-1 Temp 2"
+        label power1 "PMIC-1 ASIC 0.8V VCORE Rail Pwr (out)"
+        label power2 "PMIC-1 ASIC 1.2V Rail Pwr (out)"
+        label curr1 "PMIC-1 ASIC 0.8V VCORE Rail Curr (out)"
+        label curr2 "PMIC-1 ASIC 1.2V Rail Curr (out)"
+    chip "tps53679-i2c-*-71"
+        label in1 "PMIC-2 PSU 12V Rail (in1)"
+        label in2 "PMIC-2 PSU 12V Rail (in2)"
+        label in3 "PMIC-2 ASIC 3.3V Rail (out)"
+        compute in3 (1.5)*@, @/(1.5)
+        label in4 "PMIC-2 ASIC 1.8V Rail (out)"
+        label temp1 "PMIC-2 Temp 1"
+        label temp2 "PMIC-2 Temp 2"
+        label power1 "PMIC-2 ASIC 3.3V Rail Pwr (out)"
+        label power2 "PMIC-2 ASIC 1.8V Rail Pwr (out)"
+        label curr1 "PMIC-2 ASIC 3.3V Rail Curr (out)"
+        label curr2 "PMIC-2 ASIC 1.8V Rail Curr (out)"
+        
+    chip "mp2975-i2c-*-62"
+        label in1 "PMIC-1 PSU 12V Rail (in)"
+        label in2 "PMIC-1 ASIC 0.8V VCORE Rail (out)"
+        label in3 "PMIC-1 ASIC 1.2V Rail (out)"
+        ignore in4
+        label temp1 "PMIC-1 Temp 1"
+        label temp2 "PMIC-1 Temp 2"
+        label power1 "PMIC-1 ASIC 0.8V VCORE Rail Pwr (out)"
+        label power2 "PMIC-1 ASIC 1.2V Rail Pwr (out)"
+        label curr1 "PMIC-1 ASIC 0.8V VCORE Rail Curr (out)"
+        label curr2 "PMIC-1 ASIC 1.2V Rail Curr (out)"
+    chip "mp2975-i2c-*-66"
+        label in1 "PMIC-2 PSU 12V Rail (in)"
+        label in2 "PMIC-2 ASIC 3.3V Rail (out)"
+        compute in2 (2)*@, @/(2)
+        label in3 "PMIC-2 ASIC 1.8V Rail (out)"
+        ignore in4
+        label temp1 "PMIC-2 Temp 1"
+        label temp2 "PMIC-2 Temp 2"
+        label power1 "PMIC-2 ASIC 3.3V Rail Pwr (out)"
+        label power2 "PMIC-2 ASIC 1.8V Rail Pwr (out)"
+        label curr1 "PMIC-2 ASIC 3.3V Rail Curr (out)"
+        label curr2 "PMIC-2 ASIC 1.8V Rail Curr (out)"
+
+bus "i2c-15" "i2c-1-mux (chan_id 6)"
+    chip "tps53679-i2c-*-58"
+        label in1 "PMIC-3 PSU 12V Rail (in1)"
+        label in2 "PMIC-3 PSU 12V Rail (in2)"
+        label in3 "PMIC-3 COMEX 1.8V Rail (out)"
+        label in4 "PMIC-3 COMEX 1.05V Rail (out)"
+        label temp1 "PMIC-3 Temp 1"
+        label temp2 "PMIC-3 Temp 2"
+        label power1 "PMIC-3 COMEX 1.8V Rail Pwr (out)"
+        label power2 "PMIC-3 COMEX 1.05V Rail Pwr (out)"
+        label curr1 "PMIC-3 COMEX 1.8V Rail Curr (out)"
+        label curr2 "PMIC-3 COMEX 1.05V Rail Curr (out)"
+    chip "tps53679-i2c-*-61"
+        label in1 "PMIC-4 PSU 12V Rail (in1)"
+        label in2 "PMIC-4 PSU 12V Rail (in2)"
+        label in3 "PMIC-4 COMEX 1.2V Rail (out)"
+        ignore in4
+        label temp1 "PMIC-4 Temp 1"
+        label temp2 "PMIC-4 Temp 2"
+        label power1 "PMIC-4 COMEX 1.2V Rail Pwr (out)"
+        ignore power2
+        label curr1 "PMIC-4 COMEX 1.2V Rail Curr (out)"
+        ignore curr2
+
+    chip "mp2975-i2c-*-6a"
+        label in1 "PMIC-3 PSU 12V Rail (in1)"
+        label in2 "PMIC-3 COMEX 1.8V Rail (out)"
+        label in3 "PMIC-3 COMEX 1.05V Rail (out)"
+        label temp1 "PMIC-3 Temp 1"
+        label power1 "PMIC-3 COMEX 12V Rail Pwr (in)"
+        label power2 "PMIC-3 COMEX 1.8V Rail Pwr (out)"
+        label power3 "PMIC-3 COMEX 1.05V Rail Pwr (out)"
+        label curr1 "PMIC-3 COMEX 12V Rail Curr (in)"
+        label curr2 "PMIC-3 COMEX 1.8V Rail Curr (out)"
+        ignore curr3
+        ignore curr4
+        label curr5 "PMIC-3 COMEX 1.05V Rail Curr (out)"
+        ignore curr6
+        
+    chip "mp2975-i2c-*-61"
+        label in1 "PMIC-4 PSU 12V Rail (in1)"
+        label in2 "PMIC-4 COMEX 1.2V Rail (out)"
+        label temp1 "PMIC-4 Temp 1"
+        label temp2 "PMIC-4 Temp 2"
+        label power1 "PMIC-4 COMEX 12V Rail Pwr (in)"
+        label power2 "PMIC-4 COMEX 1.2V Rail Pwr (out)"
+        label curr1 "PMIC-4 COMEX 12V Rail Curr (in)"
+        label curr2 "PMIC-4 COMEX 1.2V Rail Curr (out)"
+        ignore curr3
+
+# Power supplies
+bus "i2c-4" "i2c-1-mux (chan_id 3)"
+    chip "dps460-i2c-*-58"
+        label in1 "PSU-1 220V Rail (in)"
+        ignore in2
+        label in3 "PSU-1 12V Rail (out)"
+        label fan1 "PSU-1 Fan 1"
+        ignore fan2
+        ignore fan3
+        label temp1 "PSU-1 Temp 1"
+        label temp2 "PSU-1 Temp 2"
+        label temp3 "PSU-1 Temp 3"
+        label power1 "PSU-1 220V Rail Pwr (in)"
+        label power2 "PSU-1 12V Rail Pwr (out)"
+        label curr1 "PSU-1 220V Rail Curr (in)"
+        label curr2 "PSU-1 12V Rail Curr (out)"
+        set in3_lcrit in3_crit * 0.662
+        set in3_min in3_crit * 0.745
+        set in3_max in3_crit * 0.952
+    chip "dps460-i2c-*-59"
+        label in1 "PSU-2 220V Rail (in)"
+        ignore in2
+        label in3 "PSU-2 12V Rail (out)"
+        label fan1 "PSU-2 Fan 1"
+        ignore fan2
+        ignore fan3
+        label temp1 "PSU-2 Temp 1"
+        label temp2 "PSU-2 Temp 2"
+        label temp3 "PSU-2 Temp 3"
+        label power1 "PSU-2 220V Rail Pwr (in)"
+        label power2 "PSU-2 12V Rail Pwr (out)"
+        label curr1 "PSU-2 220V Rail Curr (in)"
+        label curr2 "PSU-2 12V Rail Curr (out)"
+        set in3_lcrit in3_crit * 0.662
+        set in3_min in3_crit * 0.745
+        set in3_max in3_crit * 0.952
+
+# Chassis fans
+chip "mlxreg_fan-isa-*"
+    label fan1 "Chassis Fan Drawer-1 Tach 1"
+    label fan2 "Chassis Fan Drawer-1 Tach 2"
+    label fan3 "Chassis Fan Drawer-2 Tach 1"
+    label fan4 "Chassis Fan Drawer-2 Tach 2"
+    label fan5 "Chassis Fan Drawer-3 Tach 1"
+    label fan6 "Chassis Fan Drawer-3 Tach 2"
+    label fan7 "Chassis Fan Drawer-4 Tach 1"
+    label fan8 "Chassis Fan Drawer-4 Tach 2"
+    label fan9 "Chassis Fan Drawer-5 Tach 1"
+    label fan10 "Chassis Fan Drawer-5 Tach 2"
+    label fan11 "Chassis Fan Drawer-6 Tach 1"
+    label fan12 "Chassis Fan Drawer-6 Tach 2"
+
+# Miscellaneous
+chip "*-virtual-*"
+    ignore temp1

--- a/device/mellanox/x86_64-mlnx_msn3700c-r0/get_sensors_conf_path
+++ b/device/mellanox/x86_64-mlnx_msn3700c-r0/get_sensors_conf_path
@@ -1,0 +1,1 @@
+../x86_64-mlnx_msn3700-r0/get_sensors_conf_path

--- a/device/mellanox/x86_64-mlnx_msn3700c-r0/sensors_respin.conf
+++ b/device/mellanox/x86_64-mlnx_msn3700c-r0/sensors_respin.conf
@@ -1,8 +1,19 @@
-###################################################################################
-## Copyright (c) 2019 - 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-#
-# Platform specific sensors config for SN3700
-###################################################################################
+##
+## Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES.
+## Apache-2.0
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##
 
 # Temperature sensors
 bus "i2c-2" "i2c-1-mux (chan_id 1)"

--- a/device/mellanox/x86_64-mlnx_msn3700c-r0/sensors_respin.conf
+++ b/device/mellanox/x86_64-mlnx_msn3700c-r0/sensors_respin.conf
@@ -1,0 +1,172 @@
+###################################################################################
+## Copyright (c) 2019 - 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Platform specific sensors config for SN3700
+###################################################################################
+
+# Temperature sensors
+bus "i2c-2" "i2c-1-mux (chan_id 1)"
+    chip "mlxsw-i2c-*-48"
+        label temp1 "Ambient ASIC Temp"
+
+bus "i2c-7" "i2c-1-mux (chan_id 6)"
+    chip "tmp102-i2c-*-49"
+        label temp1 "Ambient Fan Side Temp (air intake)"
+    chip "tmp102-i2c-*-4a"
+        label temp1 "Ambient Port Side Temp (air exhaust)"
+
+bus "i2c-15" "i2c-1-mux (chan_id 6)"
+    chip "tmp102-i2c-15-49"
+        label temp1 "Ambient COMEX Temp"
+
+# Power controllers
+bus "i2c-5" "i2c-1-mux (chan_id 4)"
+    chip "tps53679-i2c-*-70"
+        label in1 "PMIC-1 PSU 12V Rail (in1)"
+        label in2 "PMIC-1 PSU 12V Rail (in2)"
+        label in3 "PMIC-1 ASIC 0.8V VCORE Rail (out)"
+        label in4 "PMIC-1 ASIC 1.2V Rail (out)"
+        label temp1 "PMIC-1 Temp 1"
+        label temp2 "PMIC-1 Temp 2"
+        label power1 "PMIC-1 ASIC 0.8V VCORE Rail Pwr (out)"
+        label power2 "PMIC-1 ASIC 1.2V Rail Pwr (out)"
+        label curr1 "PMIC-1 ASIC 0.8V VCORE Rail Curr (out)"
+        label curr2 "PMIC-1 ASIC 1.2V Rail Curr (out)"
+    chip "tps53679-i2c-*-71"
+        label in1 "PMIC-2 PSU 12V Rail (in1)"
+        label in2 "PMIC-2 PSU 12V Rail (in2)"
+        label in3 "PMIC-2 ASIC 3.3V Rail (out)"
+        compute in3 (1.5)*@, @/(1.5)
+        label in4 "PMIC-2 ASIC 1.8V Rail (out)"
+        label temp1 "PMIC-2 Temp 1"
+        label temp2 "PMIC-2 Temp 2"
+        label power1 "PMIC-2 ASIC 3.3V Rail Pwr (out)"
+        label power2 "PMIC-2 ASIC 1.8V Rail Pwr (out)"
+        label curr1 "PMIC-2 ASIC 3.3V Rail Curr (out)"
+        label curr2 "PMIC-2 ASIC 1.8V Rail Curr (out)"
+        
+    chip "mp2975-i2c-*-62"
+        label in1 "PMIC-1 PSU 12V Rail (in)"
+        label in2 "PMIC-1 ASIC 0.8V VCORE Rail (out)"
+        label in3 "PMIC-1 ASIC 1.2V Rail (out)"
+        ignore in4
+        label temp1 "PMIC-1 Temp 1"
+        label temp2 "PMIC-1 Temp 2"
+        label power1 "PMIC-1 ASIC 0.8V VCORE Rail Pwr (out)"
+        label power2 "PMIC-1 ASIC 1.2V Rail Pwr (out)"
+        label curr1 "PMIC-1 ASIC 0.8V VCORE Rail Curr (out)"
+        label curr2 "PMIC-1 ASIC 1.2V Rail Curr (out)"
+    chip "mp2975-i2c-*-66"
+        label in1 "PMIC-2 PSU 12V Rail (in)"
+        label in2 "PMIC-2 ASIC 3.3V Rail (out)"
+        compute in2 (2)*@, @/(2)
+        label in3 "PMIC-2 ASIC 1.8V Rail (out)"
+        ignore in4
+        label temp1 "PMIC-2 Temp 1"
+        label temp2 "PMIC-2 Temp 2"
+        label power1 "PMIC-2 ASIC 3.3V Rail Pwr (out)"
+        label power2 "PMIC-2 ASIC 1.8V Rail Pwr (out)"
+        label curr1 "PMIC-2 ASIC 3.3V Rail Curr (out)"
+        label curr2 "PMIC-2 ASIC 1.8V Rail Curr (out)"
+
+bus "i2c-15" "i2c-1-mux (chan_id 6)"
+    chip "tps53679-i2c-*-58"
+        label in1 "PMIC-3 PSU 12V Rail (in1)"
+        label in2 "PMIC-3 PSU 12V Rail (in2)"
+        label in3 "PMIC-3 COMEX 1.8V Rail (out)"
+        label in4 "PMIC-3 COMEX 1.05V Rail (out)"
+        label temp1 "PMIC-3 Temp 1"
+        label temp2 "PMIC-3 Temp 2"
+        label power1 "PMIC-3 COMEX 1.8V Rail Pwr (out)"
+        label power2 "PMIC-3 COMEX 1.05V Rail Pwr (out)"
+        label curr1 "PMIC-3 COMEX 1.8V Rail Curr (out)"
+        label curr2 "PMIC-3 COMEX 1.05V Rail Curr (out)"
+    chip "tps53679-i2c-*-61"
+        label in1 "PMIC-4 PSU 12V Rail (in1)"
+        label in2 "PMIC-4 PSU 12V Rail (in2)"
+        label in3 "PMIC-4 COMEX 1.2V Rail (out)"
+        ignore in4
+        label temp1 "PMIC-4 Temp 1"
+        label temp2 "PMIC-4 Temp 2"
+        label power1 "PMIC-4 COMEX 1.2V Rail Pwr (out)"
+        ignore power2
+        label curr1 "PMIC-4 COMEX 1.2V Rail Curr (out)"
+        ignore curr2
+
+    chip "mp2975-i2c-*-6a"
+        label in1 "PMIC-3 PSU 12V Rail (in1)"
+        label in2 "PMIC-3 COMEX 1.8V Rail (out)"
+        label in3 "PMIC-3 COMEX 1.05V Rail (out)"
+        label temp1 "PMIC-3 Temp 1"
+        label power1 "PMIC-3 COMEX 12V Rail Pwr (in)"
+        label power2 "PMIC-3 COMEX 1.8V Rail Pwr (out)"
+        label power3 "PMIC-3 COMEX 1.05V Rail Pwr (out)"
+        label curr1 "PMIC-3 COMEX 12V Rail Curr (in)"
+        label curr2 "PMIC-3 COMEX 1.8V Rail Curr (out)"
+        ignore curr3
+        ignore curr4
+        label curr5 "PMIC-3 COMEX 1.05V Rail Curr (out)"
+        ignore curr6
+        
+    chip "mp2975-i2c-*-61"
+        label in1 "PMIC-4 PSU 12V Rail (in1)"
+        label in2 "PMIC-4 COMEX 1.2V Rail (out)"
+        label temp1 "PMIC-4 Temp 1"
+        label temp2 "PMIC-4 Temp 2"
+        label power1 "PMIC-4 COMEX 12V Rail Pwr (in)"
+        label power2 "PMIC-4 COMEX 1.2V Rail Pwr (out)"
+        label curr1 "PMIC-4 COMEX 12V Rail Curr (in)"
+        label curr2 "PMIC-4 COMEX 1.2V Rail Curr (out)"
+        ignore curr3
+
+# Power supplies
+bus "i2c-4" "i2c-1-mux (chan_id 3)"
+    chip "dps460-i2c-*-58"
+        label in1 "PSU-1 220V Rail (in)"
+        ignore in2
+        label in3 "PSU-1 12V Rail (out)"
+        label fan1 "PSU-1 Fan 1"
+        ignore fan2
+        ignore fan3
+        label temp1 "PSU-1 Temp 1"
+        label temp2 "PSU-1 Temp 2"
+        label temp3 "PSU-1 Temp 3"
+        label power1 "PSU-1 220V Rail Pwr (in)"
+        label power2 "PSU-1 12V Rail Pwr (out)"
+        label curr1 "PSU-1 220V Rail Curr (in)"
+        label curr2 "PSU-1 12V Rail Curr (out)"
+        set in3_lcrit in3_crit * 0.662
+        set in3_min in3_crit * 0.745
+        set in3_max in3_crit * 0.952
+    chip "dps460-i2c-*-59"
+        label in1 "PSU-2 220V Rail (in)"
+        ignore in2
+        label in3 "PSU-2 12V Rail (out)"
+        label fan1 "PSU-2 Fan 1"
+        ignore fan2
+        ignore fan3
+        label temp1 "PSU-2 Temp 1"
+        label temp2 "PSU-2 Temp 2"
+        label temp3 "PSU-2 Temp 3"
+        label power1 "PSU-2 220V Rail Pwr (in)"
+        label power2 "PSU-2 12V Rail Pwr (out)"
+        label curr1 "PSU-2 220V Rail Curr (in)"
+        label curr2 "PSU-2 12V Rail Curr (out)"
+        set in3_lcrit in3_crit * 0.662
+        set in3_min in3_crit * 0.745
+        set in3_max in3_crit * 0.952
+
+# Chassis fans
+chip "mlxreg_fan-isa-*"
+    label fan1 "Chassis Fan Drawer-1 Tach 1"
+    label fan2 "Chassis Fan Drawer-1 Tach 2"
+    label fan3 "Chassis Fan Drawer-2 Tach 1"
+    label fan4 "Chassis Fan Drawer-2 Tach 2"
+    label fan5 "Chassis Fan Drawer-3 Tach 1"
+    label fan6 "Chassis Fan Drawer-3 Tach 2"
+    label fan7 "Chassis Fan Drawer-4 Tach 1"
+    label fan8 "Chassis Fan Drawer-4 Tach 2"
+
+# Miscellaneous
+chip "*-virtual-*"
+    ignore temp1

--- a/device/mellanox/x86_64-mlnx_msn4600c-r0/get_sensors_conf_path
+++ b/device/mellanox/x86_64-mlnx_msn4600c-r0/get_sensors_conf_path
@@ -1,1 +1,50 @@
-../x86_64-mlnx_msn4700-r0/get_sensors_conf_path
+#!/bin/bash
+
+HW_VERSION="/var/run/hw-management/system/config1"
+HW_RESPIN_VERSION="/var/run/hw-management/system/config3"
+SENSORS_CONF_FILE="/usr/share/sonic/platform/sensors.conf"
+SENSORS_RESPIN_CONF_FILE="/usr/share/sonic/platform/sensors_repin.conf"
+SENSORS_CONF_FILE_A1="/usr/share/sonic/platform/sensors.conf.a1"
+SENSORS_RESPIN_CONF_FILE_A1="/usr/share/sonic/platform/sensors_repin.conf.a1"
+
+function get_sensor_conf_path() {
+    local _HW_VERSION="0"
+    local _HW_RESPIN_VERSION="0"
+    if [[ -e $HW_VERSION ]]; then
+        _HW_VERSION=$(cat $HW_VERSION 2>&1)
+        if [[ "$_HW_VERSION" == "1" ]]; then
+            if [[ -e $HW_RESPIN_VERSION ]]; then
+                _HW_RESPIN_VERSION=$(cat $HW_RESPIN_VERSION 2>&1)
+                if [[ "$_HW_RESPIN_VERSION" == "1" ]]; then
+                    if [[ -e $SENSORS_RESPIN_CONF_FILE_A1 ]]; then
+                        echo $SENSORS_RESPIN_CONF_FILE_A1
+                        return
+                    fi
+                else 
+                    if [[ -e $SENSORS_CONF_FILE_A1 ]]; then
+                        echo $SENSORS_CONF_FILE_A1
+                        return
+                    fi
+                fi
+            else
+                if [[ -e $SENSORS_CONF_FILE_A1 ]]; then
+                        echo $SENSORS_CONF_FILE_A1
+                        return
+                fi
+            fi
+        else
+            if [[ -e $HW_RESPIN_VERSION ]]; then
+                _HW_RESPIN_VERSION=$(cat $HW_RESPIN_VERSION 2>&1)
+                if [[ "$_HW_RESPIN_VERSION" == "1" ]]; then
+                    if [[ -e $SENSORS_RESPIN_CONF_FILE ]]; then
+                        echo $SENSORS_RESPIN_CONF_FILE
+                        return
+                    fi
+                fi
+            fi
+        fi
+    fi
+    echo $SENSORS_CONF_FILE
+}
+
+get_sensor_conf_path

--- a/device/mellanox/x86_64-mlnx_msn4600c-r0/sensors_repin.conf
+++ b/device/mellanox/x86_64-mlnx_msn4600c-r0/sensors_repin.conf
@@ -1,8 +1,19 @@
-################################################################################
-# Copyright (c) 2019 Mellanox Technologies
-#
-# Platform specific sensors config for SN4700
-################################################################################
+##
+## Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES.
+## Apache-2.0
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##
 
 # Temperature sensors
 bus "i2c-2" "i2c-1-mux (chan_id 1)"

--- a/device/mellanox/x86_64-mlnx_msn4600c-r0/sensors_repin.conf
+++ b/device/mellanox/x86_64-mlnx_msn4600c-r0/sensors_repin.conf
@@ -1,0 +1,215 @@
+################################################################################
+# Copyright (c) 2019 Mellanox Technologies
+#
+# Platform specific sensors config for SN4700
+################################################################################
+
+# Temperature sensors
+bus "i2c-2" "i2c-1-mux (chan_id 1)"
+    chip "mlxsw-i2c-*-48"
+        label temp1 "Ambient ASIC Temp"
+
+bus "i2c-7" "i2c-1-mux (chan_id 6)"
+    chip "tmp102-i2c-*-49"
+        label temp1 "Ambient Fan Side Temp (air intake)"
+    chip "tmp102-i2c-*-4a"
+        label temp1 "Ambient Port Side Temp (air exhaust)"
+
+bus "i2c-15" "i2c-1-mux (chan_id 6)"
+    chip "tmp102-i2c-15-49"
+        label temp1 "Ambient COMEX Temp"
+
+# Power controllers
+bus "i2c-5" "i2c-1-mux (chan_id 4)"
+    chip "xdpe12284-i2c-*-62"
+        label in1 "PMIC-1 PSU 12V Rail (in1)"
+        ignore in2 
+        label in3 "PMIC-1 ASIC VCORE_MAIN Rail (out1)"
+        ignore in4 
+        label temp1 "PMIC-1 ASIC VCORE_MAIN Temp 1"
+        ignore temp2 
+        label power1 "PMIC-1 12V ASIC VCORE_MAIN Rail Pwr (in)"
+        ignore power2 
+        label power3 "PMIC-1 ASIC VCORE_MAIN Rail Pwr (out1)"
+        ignore power4 
+        label curr1 "PMIC-1 12V ASIC VCORE_MAIN Rail Curr (in1)"
+        ignore curr2 
+        label curr3 "PMIC-1 ASIC VCORE_MAIN Rail Curr (out1)"
+        ignore curr4 
+    chip "xdpe12284-i2c-*-64"
+        label in1 "PMIC-2 PSU 12V Rail (in1)"
+        label in2 "PMIC-2 PSU 12V Rail (in2)"
+        label in3 "PMIC-2 ASIC 1.8V_MAIN Rail (out1)"
+        label in4 "PMIC-2 ASIC 1.2V_MAIN Rail (out2)"
+        label temp1 "PMIC-2 ASIC 1.8V_MAIN Temp 1"
+        label temp2 "PMIC-2 ASIC 1.2V_MAIN Temp 2"
+        label power1 "PMIC-2 12V ASIC 1.8V_1.2V_MAIN Rail Pwr (in)"
+        ignore power2 
+        label power3 "PMIC-2 ASIC 1.8V_MAIN Rail Pwr (out1)"
+        label power4 "PMIC-2 ASIC 1.2V_MAIN Rail Pwr (out2)"
+        label curr1 "PMIC-2 12V ASIC 1.8V_MAIN Rail Curr (in1)"
+        label curr2 "PMIC-2 12V ASIC 1.2V_MAIN Rail Curr (in2)"
+        label curr3 "PMIC-2 ASIC 1.8V_MAIN Rail Curr (out1)"
+        label curr4 "PMIC-2 ASIC 1.2V_MAIN Rail Curr (out2)"
+    chip "xdpe12284-i2c-*-66"
+        label in1 "PMIC-3 PSU 12V Rail (in1)"
+        label in2 "PMIC-2 PSU 12V Rail (in2)"
+        label in3 "PMIC-3 ASIC VCORE_T0_1 Rail (out1)"
+        label in4 "PMIC-3 ASIC 1.8V_T0_1 Rail (out2)"
+        label temp1 "PMIC-3 ASIC VCORE_T0_1 Temp 1"
+        label temp2 "PMIC-3 ASIC 1.8V_T0_1 Temp 2"
+        label power1 "PMIC-3 12V ASIC VCORE_1.8V_T0_1 Rail Pwr (in) "
+        ignore power2 
+        label power3 "PMIC-2 ASIC VCORE_T0_1 Rail Pwr (out1)"
+        label power4 "PMIC-2 ASIC 1.8V_T0_1 Rail Pwr (out2)"
+        label curr1 "PMIC-2 12V ASIC VCORE_T0_1 Rail Curr (in1)"
+        label curr2 "PMIC-2 12V ASIC 1.8V_T0_1 Rail Curr (in2)"
+        label curr3 "PMIC-2 ASIC VCORE_T0_1 Rail Curr (out1)"
+        label curr4 "PMIC-2 ASIC 1.8V_T0_1 Rail Curr (out2)"
+    chip "xdpe12284-i2c-*-68"
+        label in1 "PMIC-3 PSU 12V Rail (in1)"
+        label in2 "PMIC-2 PSU 12V Rail (in2)"
+        label in3 "PMIC-3 ASIC VCORE_T2_3 Rail (out1)"
+        label in4 "PMIC-3 ASIC 1.8V_T2_3 Rail (out2)"
+        label temp1 "PMIC-3 ASIC VCORE_T2_3 Temp 1"
+        label temp2 "PMIC-3 ASIC 1.8V_T2_3 Temp 2"
+        label power1 "PMIC-3 12V ASIC VCORE_1.8V_T2_3 Rail Pwr (in) "
+        ignore power2 
+        label power3 "PMIC-2 ASIC VCORE_T2_3 Rail Pwr (out1)"
+        label power4 "PMIC-2 ASIC 1.8V_T2_3 Rail Pwr (out2)"
+        label curr1 "PMIC-2 12V ASIC VCORE_T2_3 Rail Curr (in1)"
+        label curr2 "PMIC-2 12V ASIC 1.8V_T2_3 Rail Curr (in2)"
+        label curr3 "PMIC-2 ASIC VCORE_T2_3 Rail Curr (out1)"
+        label curr4 "PMIC-2 ASIC 1.8V_T2_3 Rail Curr (out2)"
+    chip "xdpe12284-i2c-*-6a"
+        label in1 "PMIC-3 PSU 12V Rail (in1)"
+        label in2 "PMIC-2 PSU 12V Rail (in2)"
+        label in3 "PMIC-3 ASIC VCORE_T4_5 Rail (out1)"
+        label in4 "PMIC-3 ASIC 1.8V_T4_5 Rail (out2)"
+        label temp1 "PMIC-3 ASIC VCORE_T4_5 Temp 1"
+        label temp2 "PMIC-3 ASIC 1.8V_T4_5 Temp 2"
+        label power1 "PMIC-3 12V ASIC VCORE_1.8V_T4_5 Rail Pwr (in) "
+        ignore power2 
+        label power3 "PMIC-2 ASIC VCORE_T4_5 Rail Pwr (out1)"
+        label power4 "PMIC-2 ASIC 1.8V_T4_5 Rail Pwr (out2)"
+        label curr1 "PMIC-2 12V ASIC VCORE_T4_5 Rail Curr (in1)"
+        label curr2 "PMIC-2 12V ASIC 1.8V_T4_5 Rail Curr (in2)"
+        label curr3 "PMIC-2 ASIC VCORE_T4_5 Rail Curr (out1)"
+        label curr4 "PMIC-2 ASIC 1.8V_T4_5 Rail Curr (out2)"
+    chip "xdpe12284-i2c-*-6c"
+        label in1 "PMIC-3 PSU 12V Rail (in1)"
+        label in2 "PMIC-2 PSU 12V Rail (in2)"
+        label in3 "PMIC-3 ASIC VCORE_T6_7 Rail (out1)"
+        label in4 "PMIC-3 ASIC 1.8V_T6_7 Rail (out2)"
+        label temp1 "PMIC-3 ASIC VCORE_T6_7 Temp 1"
+        label temp2 "PMIC-3 ASIC 1.8V_T6_7 Temp 2"
+        label power1 "PMIC-3 12V ASIC VCORE_1.8V_T6_7 Rail Pwr (in) "
+        ignore power2 
+        label power3 "PMIC-2 ASIC VCORE_T6_7 Rail Pwr (out1)"
+        label power4 "PMIC-2 ASIC 1.8V_T6_7 Rail Pwr (out2)"
+        label curr1 "PMIC-2 12V ASIC VCORE_T6_7 Rail Curr (in1)"
+        label curr2 "PMIC-2 12V ASIC 1.8V_T6_7 Rail Curr (in2)"
+        label curr3 "PMIC-2 ASIC VCORE_T6_7 Rail Curr (out1)"
+        label curr4 "PMIC-2 ASIC 1.8V_T6_7 Rail Curr (out2)"
+    chip "xdpe12284-i2c-*-6e"
+        label in1 "PMIC-3 PSU 12V Rail (in1)"
+        label in2 "PMIC-2 PSU 12V Rail (in2)"
+        label in3 "PMIC-3 ASIC 1.2V_T0_3 Rail (out1)"
+        label in4 "PMIC-3 ASIC 1.2V_T4_7 Rail (out2)"
+        label temp1 "PMIC-3 ASIC 1.2V_T0_3 Temp 1"
+        label temp2 "PMIC-3 ASIC 1.2V_T4_7 Temp 2"
+        label power1 "PMIC-3 12V ASIC 1.2V_T0_3_T4_7 Rail Pwr (in) "
+        ignore power2 
+        label power3 "PMIC-2 ASIC 1.2V_T0_3 Rail Pwr (out1)"
+        label power4 "PMIC-2 ASIC 1.2V_T4_7 Rail Pwr (out2)"
+        label curr1 "PMIC-2 12V ASIC 1.2V_T0_3 Rail Curr (in1)"
+        label curr2 "PMIC-2 12V ASIC 1.2V_T4_7 Rail Curr (in2)"
+        label curr3 "PMIC-2 ASIC 1.2V_T0_3 Rail Curr (out1)"
+        label curr4 "PMIC-2 ASIC 1.2V_T4_7 Rail Curr (out2)"
+
+bus "i2c-15" "i2c-1-mux (chan_id 6)"
+    chip "tps53679-i2c-*-58"
+        label in1 "PMIC-8 PSU 12V Rail (in1)"
+        label in2 "PMIC-8 PSU 12V Rail (in2)"
+        label in3 "PMIC-8 COMEX 1.8V Rail (out)"
+        label in4 "PMIC-8 COMEX 1.05V Rail (out)"
+        label temp1 "PMIC-8 Temp 1"
+        label temp2 "PMIC-8 Temp 2"
+        label power1 "PMIC-8 COMEX 1.8V Rail Pwr (out)"
+        label power2 "PMIC-8 COMEX 1.05V Rail Pwr (out)"
+        label curr1 "PMIC-8 COMEX 1.8V Rail Curr (out)"
+        label curr2 "PMIC-8 COMEX 1.05V Rail Curr (out)"
+    chip "tps53679-i2c-*-61"
+        label in1 "PMIC-9 PSU 12V Rail (in1)"
+        label in2 "PMIC-9 PSU 12V Rail (in2)"
+        label in3 "PMIC-9 COMEX 1.2V Rail (out)"
+        ignore in4
+        label temp1 "PMIC-9 Temp 1"
+        label temp2 "PMIC-9 Temp 2"
+        label power1 "PMIC-9 COMEX 1.2V Rail Pwr (out)"
+        ignore power2 
+        label curr1 "PMIC-9 COMEX 1.2V Rail Curr (out)"
+        ignore curr2 
+
+    chip "mp2975-i2c-*-6a"
+        label in1 "PMIC-3 PSU 12V Rail (in1)"
+        label in2 "PMIC-3 COMEX 1.8V Rail (out)"
+        label in3 "PMIC-3 COMEX 1.05V Rail (out)"
+        label temp1 "PMIC-3 Temp 1"
+        label power1 "PMIC-3 COMEX 12V Rail Pwr (in)"
+        label power2 "PMIC-3 COMEX 1.8V Rail Pwr (out)"
+        label power3 "PMIC-3 COMEX 1.05V Rail Pwr (out)"
+        label curr1 "PMIC-3 COMEX 12V Rail Curr (in)"
+        label curr2 "PMIC-3 COMEX 1.8V Rail Curr (out)"
+        ignore curr3
+        ignore curr4
+        label curr5 "PMIC-3 COMEX 1.05V Rail Curr (out)"
+        ignore curr6
+
+    chip "mp2975-i2c-*-61"
+        label in1 "PMIC-4 PSU 12V Rail (in1)"
+        label in2 "PMIC-4 COMEX 1.2V Rail (out)"
+        label temp1 "PMIC-4 Temp 1"
+        label temp2 "PMIC-4 Temp 2"
+        label power1 "PMIC-4 COMEX 12V Rail Pwr (in)"
+        label power2 "PMIC-4 COMEX 1.2V Rail Pwr (out)"
+        label curr1 "PMIC-4 COMEX 12V Rail Curr (in)"
+        label curr2 "PMIC-4 COMEX 1.2V Rail Curr (out)"
+        ignore curr3
+
+# Power supplies
+bus "i2c-4" "i2c-1-mux (chan_id 3)"
+    chip "dps460-i2c-*-58"
+        label in1 "PSU-1(L) 220V Rail (in)"
+        ignore in2
+        label in3 "PSU-1(L) 12V Rail (out)"
+        label fan1 "PSU-1(L) Fan 1"
+        label temp1 "PSU-1(L) Temp 1"
+        label temp2 "PSU-1(L) Temp 2"
+        label temp3 "PSU-1(L) Temp 3"
+        label power1 "PSU-1(L) 220V Rail Pwr (in)"
+        label power2 "PSU-1(L) 12V Rail Pwr (out)"
+        label curr1 "PSU-1(L) 220V Rail Curr (in)"
+        label curr2 "PSU-1(L) 12V Rail Curr (out)"
+    chip "dps460-i2c-*-59"
+        label in1 "PSU-2(R) 220V Rail (in)"
+        ignore in2
+        label in3 "PSU-2(R) 12V Rail (out)"
+        label fan1 "PSU-2(R) Fan 1"
+        label temp1 "PSU-2(R) Temp 1"
+        label temp2 "PSU-2(R) Temp 2"
+        label temp3 "PSU-2(R) Temp 3"
+        label power1 "PSU-2(R) 220V Rail Pwr (in)"
+        label power2 "PSU-2(R) 12V Rail Pwr (out)"
+        label curr1 "PSU-2(R) 220V Rail Curr (in)"
+        label curr2 "PSU-2(R) 12V Rail Curr (out)"
+
+# Chassis fans
+chip "mlxreg_fan-isa-*"
+    label fan1 "Chassis Fan Drawer-1"
+    label fan2 "Chassis Fan Drawer-2"
+    label fan3 "Chassis Fan Drawer-3"
+
+# Miscellaneous
+chip "*-virtual-*"
+    ignore temp1

--- a/device/mellanox/x86_64-mlnx_msn4600c-r0/sensors_repin.conf.a1
+++ b/device/mellanox/x86_64-mlnx_msn4600c-r0/sensors_repin.conf.a1
@@ -1,0 +1,185 @@
+################################################################################
+# Copyright (c) 2019 Mellanox Technologies
+#
+# Platform specific sensors config for SN4700
+################################################################################
+
+# Temperature sensors
+bus "i2c-2" "i2c-1-mux (chan_id 1)"
+    chip "mlxsw-i2c-*-48"
+        label temp1 "Ambient ASIC Temp"
+
+bus "i2c-7" "i2c-1-mux (chan_id 6)"
+    chip "tmp102-i2c-*-49"
+        label temp1 "Ambient Fan Side Temp (air intake)"
+    chip "tmp102-i2c-*-4a"
+        label temp1 "Ambient Port Side Temp (air exhaust)"
+
+bus "i2c-15" "i2c-1-mux (chan_id 6)"
+    chip "tmp102-i2c-15-49"
+        label temp1 "Ambient COMEX Temp"
+
+# Power controllers
+bus "i2c-5" "i2c-1-mux (chan_id 4)"
+    chip "mp2975-i2c-*-62"
+        label in1 "PMIC-1 PSU 12V Rail (in)"
+        label in2 "PMIC-1 ASIC VCORE_MAIN Rail (out)"
+        ignore in3
+        ignore in4 
+        label temp1 "PMIC-1 ASIC VCORE_MAIN Temp 1"
+        ignore temp2 
+        label power1 "PMIC-1 12V ASIC VCORE_MAIN Rail Pwr (in)"
+        label power2 "PMIC-1 ASIC VCORE_MAIN Rail Pwr (out)"
+        ignore power3 
+        ignore power4 
+        label curr1 "PMIC-1 12V ASIC VCORE_MAIN Rail Curr (in)"
+        label curr2 "PMIC-1 ASIC VCORE_MAIN Rail Curr (out)"
+        ignore curr3 
+        ignore curr4 
+    chip "mp2975-i2c-*-64"
+        label in1 "PMIC-2 PSU 12V Rail (in)"
+        label in2 "PMIC-2 ASIC 1.8V_MAIN Rail (out1)"
+        label in3 "PMIC-2 ASIC 1.2V_MAIN Rail (out2)"
+        ignore in4
+        label temp1 "PMIC-2 ASIC 1.8V_1.2V_MAIN Temp 1"
+        ignore temp2
+        label power1 "PMIC-2 12V ASIC 1.8V_1.2V_MAIN Rail Pwr (in)"
+        label power2 "PMIC-2 ASIC 1.8V_MAIN Rail Pwr (out)"
+        ignore power3
+        ignore power4
+        label curr1 "PMIC-2 12V ASIC 1.8V_1.2V_MAIN Rail Curr (in)"
+        label curr2 "PMIC-2 ASIC 1.8V_MAIN Rail Curr (out1)"
+        label curr3 "PMIC-2 ASIC 1.2V_MAIN Rail Curr (out2)"
+        ignore curr4
+    chip "mp2975-i2c-*-66"
+        label in1 "PMIC-3 PSU 12V Rail (in)"
+        label in2 "PMIC-3 ASIC VCORE_T0_3 Rail (out1)"
+        label in3 "PMIC-3 ASIC 1.8V_T0_3 Rail (out2)"
+        ignore in4
+        label temp1 "PMIC-3 ASIC VCORE_1.8V_T0_3 Temp 1"
+        ignore temp2
+        label power1 "PMIC-3 12V ASIC VCORE_1.8V_T0_3 Rail Pwr (in) "
+        label power2 "PMIC-3 ASIC VCORE_T0_3 Rail Pwr (out)"
+        ignore power3
+        ignore power4 
+        label curr1 "PMIC-3 12V ASIC VCORE_1.8V_T0_3 Rail Curr (in)"
+        label curr2 "PMIC-3 ASIC VCORE_T0_3 Rail Curr (out1)"
+        label curr3 "PMIC-3 ASIC 1.8V_T0_3 Rail Curr (out2)"
+        ignore curr4
+    chip "mp2975-i2c-*-6a"
+        label in1 "PMIC-4 PSU 12V Rail (in)"
+        label in2 "PMIC-4 ASIC VCORE_T4_7 Rail (out1)"
+        label in3 "PMIC-3 ASIC 1.8V_T4_7 Rail (out2)"
+        ignore in4
+        label temp1 "PMIC-4 ASIC VCORE_1.8V_T4_7 Temp 1"
+        ignore temp2
+        label power1 "PMIC-4 12V ASIC VCORE_1.8V_T4_7 Rail Pwr (in) "
+        label power2 "PMIC-4 ASIC VCORE_T4_7 Rail Pwr (out)"
+        ignore power3
+        ignore power4 
+        label curr1 "PMIC-4 12V ASIC VCORE_1.8V_T4_7 Rail Curr (in)"
+        label curr2 "PMIC-4 ASIC VCORE_T4_7 Rail Curr (out1)"
+        label curr3 "PMIC-4 ASIC 1.8V_T4_7 Rail Curr (out2)"
+        ignore curr4
+        ignore curr4
+    chip "mp2975-i2c-*-6e"
+        label in1 "PMIC-5 PSU 12V Rail (in)"
+        label in2 "PMIC-5 ASIC 1.2V_T0_3 Rail (out1)"
+        label in3 "PMIC-5 ASIC 1.2V_T4_7 Rail (out2)"
+        ignore in4
+        label temp1 "PMIC-5 ASIC 1.2V_T0_3_T4_7 Temp 1"
+        ignore temp2
+        label power1 "PMIC-5 12V ASIC 1.2V_T0_3_T4_7 Rail Pwr (in)"
+        label power2 "PMIC-5 ASIC 1.2V_T0_3 Rail Pwr (out)"
+        ignore power3
+        ignore power4
+        label curr1 "PMIC-5 12V ASIC 1.2V_T0_3_T4_7 Rail Curr (in)"
+        label curr2 "PMIC-5 ASIC 1.2V_T0_3 Rail Curr (out1)"
+        label curr3 "PMIC-5 ASIC 1.2V_T4_7 Rail Curr (out2)"
+        ignore curr4
+bus "i2c-15" "i2c-1-mux (chan_id 6)"
+    chip "tps53679-i2c-*-58"
+        label in1 "PMIC-6 PSU 12V Rail (in1)"
+        label in2 "PMIC-6 PSU 12V Rail (in2)"
+        label in3 "PMIC-6 COMEX 1.8V Rail (out1)"
+        label in4 "PMIC-6 COMEX 1.05V Rail (out2)"
+        label temp1 "PMIC-6 Temp 1"
+        label temp2 "PMIC-6 Temp 2"
+        label power1 "PMIC-6 COMEX 1.8V Rail Pwr (out1)"
+        label power2 "PMIC-6 COMEX 1.05V Rail Pwr (out2)"
+        label curr1 "PMIC-6 COMEX 1.8V Rail Curr (out1)"
+        label curr2 "PMIC-6 COMEX 1.05V Rail Curr (out2)"
+    chip "tps53679-i2c-*-61"
+        label in1 "PMIC-7 PSU 12V Rail (in1)"
+        label in2 "PMIC-7 PSU 12V Rail (in2)"
+        label in3 "PMIC-7 COMEX 1.2V Rail (out)"
+        ignore in4
+        label temp1 "PMIC-7 Temp 1"
+        label temp2 "PMIC-7 Temp 2"
+        label power1 "PMIC-7 COMEX 1.2V Rail Pwr (out1)"
+        ignore power2 
+        label curr1 "PMIC-7 COMEX 1.2V Rail Curr (out1)"
+        ignore curr2 
+
+    chip "mp2975-i2c-*-6a"
+        label in1 "PMIC-3 PSU 12V Rail (in1)"
+        label in2 "PMIC-3 COMEX 1.8V Rail (out)"
+        label in3 "PMIC-3 COMEX 1.05V Rail (out)"
+        label temp1 "PMIC-3 Temp 1"
+        label power1 "PMIC-3 COMEX 12V Rail Pwr (in)"
+        label power2 "PMIC-3 COMEX 1.8V Rail Pwr (out)"
+        label power3 "PMIC-3 COMEX 1.05V Rail Pwr (out)"
+        label curr1 "PMIC-3 COMEX 12V Rail Curr (in)"
+        label curr2 "PMIC-3 COMEX 1.8V Rail Curr (out)"
+        ignore curr3
+        ignore curr4
+        label curr5 "PMIC-3 COMEX 1.05V Rail Curr (out)"
+        ignore curr6
+
+    chip "mp2975-i2c-*-61"
+        label in1 "PMIC-4 PSU 12V Rail (in1)"
+        label in2 "PMIC-4 COMEX 1.2V Rail (out)"
+        label temp1 "PMIC-4 Temp 1"
+        label temp2 "PMIC-4 Temp 2"
+        label power1 "PMIC-4 COMEX 12V Rail Pwr (in)"
+        label power2 "PMIC-4 COMEX 1.2V Rail Pwr (out)"
+        label curr1 "PMIC-4 COMEX 12V Rail Curr (in)"
+        label curr2 "PMIC-4 COMEX 1.2V Rail Curr (out)"
+        ignore curr3
+
+# Power supplies
+bus "i2c-4" "i2c-1-mux (chan_id 3)"
+    chip "dps460-i2c-*-58"
+        label in1 "PSU-1(L) 220V Rail (in)"
+        ignore in2
+        label in3 "PSU-1(L) 12V Rail (out)"
+        label fan1 "PSU-1(L) Fan 1"
+        label temp1 "PSU-1(L) Temp 1"
+        label temp2 "PSU-1(L) Temp 2"
+        label temp3 "PSU-1(L) Temp 3"
+        label power1 "PSU-1(L) 220V Rail Pwr (in)"
+        label power2 "PSU-1(L) 12V Rail Pwr (out)"
+        label curr1 "PSU-1(L) 220V Rail Curr (in)"
+        label curr2 "PSU-1(L) 12V Rail Curr (out)"
+    chip "dps460-i2c-*-59"
+        label in1 "PSU-2(R) 220V Rail (in)"
+        ignore in2
+        label in3 "PSU-2(R) 12V Rail (out)"
+        label fan1 "PSU-2(R) Fan 1"
+        label temp1 "PSU-2(R) Temp 1"
+        label temp2 "PSU-2(R) Temp 2"
+        label temp3 "PSU-2(R) Temp 3"
+        label power1 "PSU-2(R) 220V Rail Pwr (in)"
+        label power2 "PSU-2(R) 12V Rail Pwr (out)"
+        label curr1 "PSU-2(R) 220V Rail Curr (in)"
+        label curr2 "PSU-2(R) 12V Rail Curr (out)"
+
+# Chassis fans
+chip "mlxreg_fan-isa-*"
+    label fan1 "Chassis Fan Drawer-1"
+    label fan2 "Chassis Fan Drawer-2"
+    label fan3 "Chassis Fan Drawer-3"
+
+# Miscellaneous
+chip "*-virtual-*"
+    ignore temp1


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

MSN3700/3700C/4600C have been respined, the new HW version of platforms has different sensors, so need to apply the correct sensor.conf for them.

#### How I did it

Add new sensor.conf files for the new respined platforms.
Enhance the logic of "get_sensors_conf_path" for the related platforms in order to load correct sensor.conf for each version of platforms.

#### How to verify it

run sensors test on different version of platforms

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

