### PR TITLE
[Mellanox] Add new sensor conf to support SN4410 A1 system 

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn4410-r0/get_sensors_conf_path
+++ b/device/mellanox/x86_64-mlnx_msn4410-r0/get_sensors_conf_path
@@ -1,0 +1,1 @@
+../x86_64-mlnx_msn4700-r0/get_sensors_conf_path

--- a/device/mellanox/x86_64-mlnx_msn4410-r0/sensors.conf.a1
+++ b/device/mellanox/x86_64-mlnx_msn4410-r0/sensors.conf.a1
@@ -1,0 +1,1 @@
+../x86_64-mlnx_msn4700-r0/sensors.conf.a1


### PR DESCRIPTION
#### Why I did it

New SN410 A1 system has a different sensor layout with A0 system, needs a new sensor conf file to support it.

#### How I did it

Since the SN4410 A1 system use exactly the same sensor layout as the SN4700 A1 system, so add a symbol link linking to the SN4700 A1 sensor conf file to reuse.

#### How to verify it

Run sensor test against the SN4410 A1 system;
Run platform related regression test against the SN4410 A1 system


#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

