### PR TITLE
[202205][Mellanox] Update SAI build procedure (#15728)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -73,9 +73,6 @@
 [submodule "src/scapy"]
 	path = src/scapy
 	url = https://github.com/secdev/scapy.git
-[submodule "platform/mellanox/mlnx-sai/SAI-Implementation"]
-	path = platform/mellanox/mlnx-sai/SAI-Implementation
-	url = https://github.com/Mellanox/SAI-Implementation
 [submodule "src/sonic-mgmt-framework"]
 	path = src/sonic-mgmt-framework
 	url = https://github.com/sonic-net/sonic-mgmt-framework

--- a/platform/mellanox/.gitignore
+++ b/platform/mellanox/.gitignore
@@ -1,6 +1,4 @@
 # Subdirectories
-mlnx-sai/*
-!mlnx-sai/Makefile
 hw-management/*
 !hw-management/Makefile
 !hw-management/*.patch

--- a/platform/mellanox/mlnx-sai.mk
+++ b/platform/mellanox/mlnx-sai.mk
@@ -1,8 +1,21 @@
 # Mellanox SAI
 
 MLNX_SAI_VERSION = SAIBuild2205.24.0.2
+MLNX_SAI_ASSETS_GITHUB_URL = https://github.com/Mellanox/Spectrum-SDK-Drivers-SONiC-Bins
+MLNX_SAI_ASSETS_RELEASE_TAG = sai-$(MLNX_SAI_VERSION)-$(BLDENV)-$(CONFIGURED_ARCH)
+MLNX_SAI_ASSETS_URL = $(MLNX_ASSETS_GITHUB_URL)/releases/download/$(MLNX_SAI_ASSETS_RELEASE_TAG)
+MLNX_SAI_DEB_VERSION = $(subst -,.,$(subst _,.,$(MLNX_SAI_VERSION)))
 
-export MLNX_SAI_VERSION
+# Place here URL where SAI sources exist
+MLNX_SAI_SOURCE_BASE_URL = 
+
+ifneq ($(MLNX_SAI_SOURCE_BASE_URL), )
+SAI_FROM_SRC = y
+else
+SAI_FROM_SRC = n
+endif
+
+export MLNX_SAI_VERSION MLNX_SAI_SOURCE_BASE_URL
 
 MLNX_SAI = mlnx-sai_1.mlnx.$(MLNX_SAI_VERSION)_amd64.deb
 $(MLNX_SAI)_SRC_PATH = $(PLATFORM_PATH)/mlnx-sai
@@ -11,4 +24,16 @@ $(MLNX_SAI)_RDEPENDS += $(MLNX_SDK_RDEBS) $(MLNX_SDK_DEBS)
 $(eval $(call add_conflict_package,$(MLNX_SAI),$(LIBSAIVS_DEV)))
 MLNX_SAI_DBGSYM = mlnx-sai-dbgsym_1.mlnx.$(MLNX_SAI_VERSION)_amd64.deb
 $(eval $(call add_derived_package,$(MLNX_SAI),$(MLNX_SAI_DBGSYM)))
+
+define make_url
+	$(1)_URL = $(MLNX_SAI_ASSETS_URL)/$(1)
+
+endef
+
+$(eval $(foreach deb,$(MLNX_SAI) $(MLNX_SAI_DBGSYM),$(call make_url,$(deb))))
+
+ifeq ($(SAI_FROM_SRC), y)
 SONIC_MAKE_DEBS += $(MLNX_SAI)
+else
+SONIC_ONLINE_DEBS += $(MLNX_SAI)
+endif

--- a/platform/mellanox/mlnx-sai/.gitignore
+++ b/platform/mellanox/mlnx-sai/.gitignore
@@ -1,0 +1,6 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore
+!Makefile
+

--- a/platform/mellanox/mlnx-sai/Makefile
+++ b/platform/mellanox/mlnx-sai/Makefile
@@ -6,11 +6,11 @@ MAIN_TARGET = mlnx-sai_1.mlnx.$(MLNX_SAI_VERSION)_amd64.deb
 DERIVED_TARGETS = mlnx-sai-dbgsym_1.mlnx.$(MLNX_SAI_VERSION)_amd64.deb
 
 $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
-	pushd SAI-Implementation
+	rm -rf mlnx_sai
+	wget -c $(MLNX_SAI_SOURCE_BASE_URL)/$(MLNX_SAI_VERSION).tar.gz -O - | tar -xz
 	pushd mlnx_sai
 
 	debuild -e 'make_extra_flags="DEFS=-DACS_OS -DCONFIG_SYSLOG"' -us -uc -d -b
 	popd
 
 	mv $(DERIVED_TARGETS) $* $(DEST)/
-	popd


### PR DESCRIPTION
= Why I did it
To optimize Mellanox platform SAI build

- How I did it SAI debs are now downloaded as Spectrum-SDK-Drivers-SONiC-Bins release.

- How to verify it Configure/build for Mellanox platform, check the image and ensure that correct SAI debs are included.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

