### PR TITLE
Add special rsyslog filter for MSN2700 platform

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2700-r0/01_mlnx_2700_syslog.conf
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/01_mlnx_2700_syslog.conf
@@ -1,5 +1,6 @@
-# This rsyslog configuration intends to eliminate following error msg which only MSN2700 platform:
+# This rsyslog configuration is intended to resolve the following error message that only appears on the MSN2700 platform:
 # "ERR pmon#sensord: Error getting sensor data: dps460/#10: Can't read"
-# This error is because of FW issue with some type of PSU, we are not able to upgrade the FW online.
-# Since there is no functional impaction, this error log can be ignored safely.
+# This error is because of firmware issue with some type of PSU, we are not able to upgrade the FW online.
+# Since there is no functional impact, this error log can be ignored safely.
+
 if $programname contains "sensord" and $msg contains "Error getting sensor data: dps460/#" then stop

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/01_mlnx_2700_syslog.conf
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/01_mlnx_2700_syslog.conf
@@ -1,0 +1,5 @@
+# This rsyslog configuration intends to eliminate following error msg which only MSN2700 platform:
+# "ERR pmon#sensord: Error getting sensor data: dps460/#10: Can't read"
+# This error is because of FW issue with some type of PSU, we are not able to upgrade the FW online.
+# Since there is no functional impaction, this error log can be ignored safely.
+if $programname contains "sensord" and $msg contains "Error getting sensor data: dps460/#" then stop

--- a/device/mellanox/x86_64-mlnx_msn2700a1-r0/01_mlnx_2700_syslog.conf
+++ b/device/mellanox/x86_64-mlnx_msn2700a1-r0/01_mlnx_2700_syslog.conf
@@ -1,0 +1,1 @@
+../x86_64-mlnx_msn2700-r0/01_mlnx_2700_syslog.conf

--- a/files/image_config/platform/rc.local
+++ b/files/image_config/platform/rc.local
@@ -209,8 +209,9 @@ program_console_speed()
 
 handle_platform_specific_config()
 {
-    # Nvidia x86_64-mlnx_msn2700-r0 need a special rsyslog configuration,
-    # detail infomation please check the config file itself.
+    # Mellanox MSN2700 platforms need a special rsyslog configuration to 
+    # eliminate some non-functional error log.
+    # Copy this configuration file to /etc/rsyslog.d/ during first time boot.
     platform_name=$1
     src_file_name=/usr/share/sonic/device/$platform_name/01_mlnx_2700_syslog.conf
     target_file_name=/etc/rsyslog.d/01_mlnx_2700_syslog.conf

--- a/files/image_config/platform/rc.local
+++ b/files/image_config/platform/rc.local
@@ -207,6 +207,16 @@ program_console_speed()
     systemctl daemon-reload
 }
 
+handle_platform_specific_config()
+{
+    platform_name=$1
+    # Nvidia x86_64-mlnx_msn2700-r0 need a special rsyslog configuration,
+    # detail infomation please check the config file itself.
+    if [ "$platfrom_name" == "x86_64-mlnx_msn2700-r0" ]; then
+        [ -f /usr/share/sonic/device/$platfrom_name/01_mlnx_2700_syslog.conf ] && cp /usr/share/sonic/device/$platfrom_name/01_mlnx_2700_syslog.conf /etc/rsyslog.d/01_mlnx_2700_syslog.conf
+    fi
+}
+
 
 #### Begin Main Body ####
 
@@ -395,6 +405,9 @@ if [ -f $FIRST_BOOT_FILE ]; then
 
     # Kdump tools configuration
     [ -f /etc/default/kdump-tools ] && sed -i -e "s/__PLATFORM__/$platform/g" /etc/default/kdump-tools
+
+    # Handle platform specific config
+    handle_platform_specific_config $platform
 
     firsttime_exit
 fi

--- a/files/image_config/platform/rc.local
+++ b/files/image_config/platform/rc.local
@@ -222,7 +222,6 @@ handle_platform_specific_config()
     fi
 }
 
-
 #### Begin Main Body ####
 
 logger "SONiC version ${SONIC_VERSION} starting up..."

--- a/files/image_config/platform/rc.local
+++ b/files/image_config/platform/rc.local
@@ -209,11 +209,16 @@ program_console_speed()
 
 handle_platform_specific_config()
 {
-    platform_name=$1
     # Nvidia x86_64-mlnx_msn2700-r0 need a special rsyslog configuration,
     # detail infomation please check the config file itself.
-    if [ "$platfrom_name" == "x86_64-mlnx_msn2700-r0" ]; then
-        [ -f /usr/share/sonic/device/$platfrom_name/01_mlnx_2700_syslog.conf ] && cp /usr/share/sonic/device/$platfrom_name/01_mlnx_2700_syslog.conf /etc/rsyslog.d/01_mlnx_2700_syslog.conf
+    platform_name=$1
+    src_file_name=/usr/share/sonic/device/$platform_name/01_mlnx_2700_syslog.conf
+    target_file_name=/etc/rsyslog.d/01_mlnx_2700_syslog.conf
+
+    if [ "$platform_name" = "x86_64-mlnx_msn2700a1-r0" ] || [ "$platform_name" = "x86_64-mlnx_msn2700-r0" ]; then
+        if [ -e $src_file_name ]; then
+            cp $src_file_name $target_file_name
+        fi
     fi
 }
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

Mellanox MSN2700 platforms have a non-functional error log:  "ERR pmon#sensord: Error getting sensor data: dps460/#10: Can't read".  This error is because of a firmware issue with some PSU, we are not able to upgrade the FW online. Since there is no functional impact, this error log can be ignored safely.

#### How I did it

Add a new rsyslog configuration to the platform folder, during the first time boot, copy this configuration file to "/etc/rsyslog.d/" folder so rsyslogd will load it.

#### How to verify it

run regression on the MSN2700 platform to make the error log will not be printed to the syslog.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

