### PR TITLE
[Mellanox][SN2201] Fix wrong sfp number on SN2201 platform

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2023 NVIDIA CORPORATION & AFFILIATES.
+# Copyright (c) 2019-2024 NVIDIA CORPORATION & AFFILIATES.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -329,7 +329,13 @@ class Chassis(ChassisBase):
         Returns:
             An integer, the number of sfps available on this chassis
         """
-        return DeviceDataManager.get_sfp_count()
+        if not self._RJ45_port_inited:
+            self._RJ45_port_list = extract_RJ45_ports_index()
+            self._RJ45_port_inited = True
+        if self._RJ45_port_list is not None:
+            return DeviceDataManager.get_sfp_count() + len(self._RJ45_port_list)
+        else:
+            return DeviceDataManager.get_sfp_count()
 
     def get_all_sfps(self):
         """

--- a/platform/mellanox/mlnx-platform-api/tests/test_chassis.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_chassis.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021-2023 NVIDIA CORPORATION & AFFILIATES.
+# Copyright (c) 2021-2024 NVIDIA CORPORATION & AFFILIATES.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -168,6 +168,13 @@ class TestChassis:
         sfp_list = chassis.get_all_sfps()
         assert len(sfp_list) == 3
         assert chassis.sfp_initialized_count == 3
+
+        # Get all SFPs, with RJ45 ports
+        sonic_platform.chassis.extract_RJ45_ports_index = mock.MagicMock(return_value=[0,1,2])
+        DeviceDataManager.get_sfp_count = mock.MagicMock(return_value=3)
+        chassis = Chassis()
+        assert chassis.get_num_sfps() == 6
+        sonic_platform.chassis.extract_RJ45_ports_index = mock.MagicMock(return_value=[])
 
     def test_create_sfp_in_multi_thread(self):
         DeviceDataManager.get_sfp_count = mock.MagicMock(return_value=3)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

For the SN2201 platform, it includes both RJ45 ports and SFP ports, in the recent new chassis.get_num_sfps() implementation, it will only count the number of SFP ports, however, as the design, on this platform, RJ45 ports should also be counted to correctly initialize the SFP objects list inside the Chassis. The RJ45 ports are treated as a special type of SFP object in the Mellanox platform API implementation.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

count both SFP ports number and RJ45 ports number in  chassis.get_num_sfps().

#### How to verify it

run SFP related sonic-mgmt tests on SN2201 and other Mellanox platforms to make sure it can pass.
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [x] 202311

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

