### PR TITLE
[PMON] Support to fetch pmon_daemon_control.json file from both platform and HWSKU folders

### DIFF
--- a/dockers/docker-platform-monitor/docker_init.j2
+++ b/dockers/docker-platform-monitor/docker_init.j2
@@ -8,7 +8,6 @@ FANCONTROL_CONF_FILE="/usr/share/sonic/platform/fancontrol"
 
 SUPERVISOR_CONF_TEMPLATE="/usr/share/sonic/templates/docker-pmon.supervisord.conf.j2"
 SUPERVISOR_CONF_FILE="/etc/supervisor/conf.d/supervisord.conf"
-PMON_DAEMON_CONTROL_FILE="/usr/share/sonic/platform/pmon_daemon_control.json"
 MODULAR_CHASSISDB_CONF_FILE="/usr/share/sonic/platform/chassisdb.conf"
 
 HAVE_SENSORS_CONF=0
@@ -16,6 +15,13 @@ HAVE_FANCONTROL_CONF=0
 IS_MODULAR_CHASSIS=0
 # Default use python2 version
 SONIC_PLATFORM_API_PYTHON_VERSION=2
+
+if [ -e /usr/share/sonic/hwsku/pmon_daemon_control.json ];
+then
+    PMON_DAEMON_CONTROL_FILE="/usr/share/sonic/hwsku/pmon_daemon_control.json"
+else
+    PMON_DAEMON_CONTROL_FILE="/usr/share/sonic/platform/pmon_daemon_control.json"
+fi
 
 declare -r EXIT_SUCCESS="0"
 


### PR DESCRIPTION


<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

The pmon_daemon_control.json file currently has a platform-specific scope, resulting in all SKUs of the same platform sharing the same pmon daemon configuration. Consequently, this restricts the ability to have distinct pmon daemon configurations for different SKUs. The proposed change aims to enhance flexibility by allowing PMON to load this file from both the platform folder and the HWSKU folder. In case a pmon_daemon_control.json file exists in the HWSKU folder, it will take precedence over the one in the platform folder.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

The pmon docker init script will be updated to prioritize the HWSKU folder when searching for the pmon_daemon_control.json file. If the file is present in the HWSKU folder, it will be utilized. However, if the file does not exist in the HWSKU folder, the script will then fallback to utilizing the one located in the platform folder.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->
Build image with this change, put the file in 
1. platform folder, 
2. in HWSKU folder
3. in both folders

make sure the pmon daemons started according to the configuration.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [x] 202311

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

