### PR TITLE
[Coding Practice] Implement PWM class based on pwm_base in Nvidia platform API

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
@@ -133,6 +133,7 @@ class Chassis(ChassisBase):
         self._asic_id_map = None
 
         self.liquid_cooling = None
+        self._pwm = None
 
         Chassis.chassis_instance = self
 
@@ -1246,6 +1247,19 @@ class Chassis(ChassisBase):
     def get_liquid_cooling(self):
         self.initialize_liquid_cooling()
         return self.liquid_cooling
+
+    ##############################################
+    # PWM methods
+    ##############################################
+
+    def initialize_pwm(self):
+        if not self._pwm:
+            from .pwm import PWM
+            self._pwm = PWM()
+
+    def get_pwm(self):
+        self.initialize_pwm()
+        return self._pwm
 
 
 class ModularChassis(Chassis):

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/pwm.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/pwm.py
@@ -29,7 +29,7 @@ except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
 
-PWM_FILE_PATH = "/var/run/hw-management/thermal/pwm"
+PWM_FILE_PATH = "/var/run/hw-management/thermal/pwm11111111111"
 PWM_NAME = "pwm"
 PWM_MIN_THRESHOLD = 0
 PWM_MAX_THRESHOLD = 255

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/pwm.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/pwm.py
@@ -1,0 +1,145 @@
+#
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#############################################################################
+# Mellanox
+#
+# Module contains an implementation of PWM API
+#
+#############################################################################
+
+try:
+    from sonic_platform_base.pwm_base import PwmBase
+    from . import utils
+except ImportError as e:
+    raise ImportError(str(e) + "- required module not found")
+
+
+PWM_FILE_PATH = "/var/run/hw-management/thermal/pwm"
+PWM_NAME = "pwm"
+PWM_MIN_THRESHOLD = 0
+PWM_MAX_THRESHOLD = 255
+
+
+class PWM(PwmBase):
+    """
+    PWM encapsulates PWM device functionality.
+    Reads PWM value from hw-management thermal subsystem.
+    """
+
+    def __init__(self):
+        super().__init__()
+
+    def get_name(self):
+        """
+        Retrieves the name of the PWM device
+
+        Returns:
+            string: The name of the PWM device
+        """
+        return PWM_NAME
+
+    def get_presence(self):
+        """
+        Retrieves the presence of the PWM device
+
+        Returns:
+            bool: True if PWM device is present, False if not
+        """
+        import os
+        return os.path.exists(PWM_FILE_PATH)
+
+    def get_model(self):
+        """
+        Retrieves the model number of the PWM device
+
+        Returns:
+            string: Model number of device
+        """
+        return "N/A"
+
+    def get_serial(self):
+        """
+        Retrieves the serial number of the PWM device
+
+        Returns:
+            string: Serial number of device
+        """
+        return "N/A"
+
+    def get_revision(self):
+        """
+        Retrieves the hardware revision of the PWM device
+
+        Returns:
+            string: Revision value of device
+        """
+        return "N/A"
+
+    def get_status(self):
+        """
+        Retrieves the operational status of the PWM device
+
+        Returns:
+            bool: True if PWM device is operating properly, False if not
+        """
+        return self.get_presence()
+
+    def get_position_in_parent(self):
+        """
+        Retrieves 1-based relative physical position in parent device.
+
+        Returns:
+            int: The 1-based relative physical position in parent device
+        """
+        return 1
+
+    def is_replaceable(self):
+        """
+        Indicate whether this device is replaceable.
+
+        Returns:
+            bool: True if it is replaceable.
+        """
+        return False
+
+    def get_pwm_value(self):
+        """
+        Retrieves the current PWM value
+
+        Returns:
+            int: The current PWM value (0-255)
+        """
+        return utils.read_int_from_file(PWM_FILE_PATH, default=0)
+
+    def get_pwm_max_threshold(self):
+        """
+        Retrieves the maximum PWM threshold value
+
+        Returns:
+            int: The maximum PWM threshold value (255)
+        """
+        return PWM_MAX_THRESHOLD
+
+    def get_pwm_min_threshold(self):
+        """
+        Retrieves the minimum PWM threshold value
+
+        Returns:
+            int: The minimum PWM threshold value (0)
+        """
+        return PWM_MIN_THRESHOLD

--- a/platform/mellanox/mlnx-platform-api/tests/test_chassis.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_chassis.py
@@ -333,6 +333,33 @@ class TestChassis:
         content = chassis._parse_vpd_data(os.path.join(test_path, 'vpd_data_file'))
         assert content.get('REV') == 'A7'
 
+    def test_pwm(self):
+        from sonic_platform.pwm import PWM
+        chassis = Chassis()
+
+        # Test that PWM is not initialized by default
+        assert chassis._pwm is None
+
+        # Test initialize_pwm
+        chassis.initialize_pwm()
+        assert chassis._pwm is not None
+        assert isinstance(chassis._pwm, PWM)
+
+        # Test that initialize_pwm doesn't create a new PWM if already initialized
+        pwm_instance = chassis._pwm
+        chassis.initialize_pwm()
+        assert chassis._pwm is pwm_instance
+
+        # Test get_pwm
+        chassis._pwm = None
+        pwm = chassis.get_pwm()
+        assert pwm is not None
+        assert isinstance(pwm, PWM)
+
+        # Test get_pwm returns the same instance
+        pwm2 = chassis.get_pwm()
+        assert pwm is pwm2
+
     @mock.patch('sonic_platform.module.SonicV2Connector', mock.MagicMock())
     @mock.patch('sonic_platform.module.ConfigDBConnector', mock.MagicMock())
     def test_smartswitch(self):

--- a/platform/mellanox/mlnx-platform-api/tests/test_pwm.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_pwm.py
@@ -1,0 +1,117 @@
+#
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+# Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+import sys
+from unittest import mock
+
+test_path = os.path.dirname(os.path.abspath(__file__))
+modules_path = os.path.dirname(test_path)
+sys.path.insert(0, modules_path)
+
+from sonic_platform.pwm import PWM, PWM_FILE_PATH, PWM_NAME, PWM_MIN_THRESHOLD, PWM_MAX_THRESHOLD
+
+
+class TestPWM:
+    def test_pwm_get_name(self):
+        """Test get_name returns correct PWM name"""
+        pwm = PWM()
+        assert pwm.get_name() == PWM_NAME
+        assert pwm.get_name() == "pwm"
+
+    def test_pwm_get_presence_file_exists(self):
+        """Test get_presence returns True when PWM file exists"""
+        pwm = PWM()
+        with mock.patch('os.path.exists', return_value=True):
+            assert pwm.get_presence() is True
+
+    def test_pwm_get_presence_file_not_exists(self):
+        """Test get_presence returns False when PWM file does not exist"""
+        pwm = PWM()
+        with mock.patch('os.path.exists', return_value=False):
+            assert pwm.get_presence() is False
+
+    def test_pwm_get_model(self):
+        """Test get_model returns N/A"""
+        pwm = PWM()
+        assert pwm.get_model() == "N/A"
+
+    def test_pwm_get_serial(self):
+        """Test get_serial returns N/A"""
+        pwm = PWM()
+        assert pwm.get_serial() == "N/A"
+
+    def test_pwm_get_revision(self):
+        """Test get_revision returns N/A"""
+        pwm = PWM()
+        assert pwm.get_revision() == "N/A"
+
+    def test_pwm_get_status(self):
+        """Test get_status returns presence status"""
+        pwm = PWM()
+        with mock.patch('os.path.exists', return_value=True):
+            assert pwm.get_status() is True
+        with mock.patch('os.path.exists', return_value=False):
+            assert pwm.get_status() is False
+
+    def test_pwm_get_position_in_parent(self):
+        """Test get_position_in_parent returns 1"""
+        pwm = PWM()
+        assert pwm.get_position_in_parent() == 1
+
+    def test_pwm_is_replaceable(self):
+        """Test is_replaceable returns False"""
+        pwm = PWM()
+        assert pwm.is_replaceable() is False
+
+    def test_pwm_get_pwm_value(self):
+        """Test get_pwm_value reads value from file"""
+        pwm = PWM()
+        with mock.patch('sonic_platform.utils.read_int_from_file', return_value=128) as mock_read:
+            result = pwm.get_pwm_value()
+            assert result == 128
+            mock_read.assert_called_once_with(PWM_FILE_PATH, default=0)
+
+    def test_pwm_get_pwm_value_min(self):
+        """Test get_pwm_value with minimum value"""
+        pwm = PWM()
+        with mock.patch('sonic_platform.utils.read_int_from_file', return_value=0):
+            assert pwm.get_pwm_value() == 0
+
+    def test_pwm_get_pwm_value_max(self):
+        """Test get_pwm_value with maximum value"""
+        pwm = PWM()
+        with mock.patch('sonic_platform.utils.read_int_from_file', return_value=255):
+            assert pwm.get_pwm_value() == 255
+
+    def test_pwm_get_pwm_max_threshold(self):
+        """Test get_pwm_max_threshold returns 255"""
+        pwm = PWM()
+        assert pwm.get_pwm_max_threshold() == PWM_MAX_THRESHOLD
+        assert pwm.get_pwm_max_threshold() == 255
+
+    def test_pwm_get_pwm_min_threshold(self):
+        """Test get_pwm_min_threshold returns 0"""
+        pwm = PWM()
+        assert pwm.get_pwm_min_threshold() == PWM_MIN_THRESHOLD
+        assert pwm.get_pwm_min_threshold() == 0
+
+    def test_pwm_inherits_from_pwm_base(self):
+        """Test PWM class inherits from PwmBase"""
+        from sonic_platform_base.pwm_base import PwmBase
+        pwm = PWM()
+        assert isinstance(pwm, PwmBase)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

