### PR TITLE
[Coding Practice] Extend system-health-monitor to support pwm monitoring

### DIFF
--- a/src/system-health/health_checker/hardware_checker.py
+++ b/src/system-health/health_checker/hardware_checker.py
@@ -15,6 +15,7 @@ class HardwareChecker(HealthChecker):
     ASIC_TEMPERATURE_KEY = 'TEMPERATURE_INFO|ASIC'
     FAN_TABLE_NAME = 'FAN_INFO'
     PSU_TABLE_NAME = 'PSU_INFO'
+    PWM_TABLE_NAME = 'PWM_INFO'
     LIQUID_COOLING_TABLE_NAME = 'LIQUID_COOLING_INFO'
 
     def __init__(self):
@@ -32,6 +33,7 @@ class HardwareChecker(HealthChecker):
         self._check_asic_status(config)
         self._check_fan_status(config)
         self._check_psu_status(config)
+        self._check_pwm_status(config)
         self._check_liquid_cooling_status(config)
 
     def _check_asic_status(self, config):
@@ -276,6 +278,50 @@ class HardwareChecker(HealthChecker):
                     continue
 
             self.set_object_ok('PSU', name)
+
+    def _check_pwm_status(self, config):
+        """
+        Check PWM status including:
+            1. Check PWM value is within valid thresholds
+        :param config: Health checker configuration
+        :return:
+        """
+        if config.ignore_devices and 'pwm' in config.ignore_devices:
+            return
+
+        keys = self._db.keys(self._db.STATE_DB, HardwareChecker.PWM_TABLE_NAME + '*')
+        if not keys:
+            # PWM info may not be available on all platforms, so don't report error if no keys found
+            return
+
+        for key in natsorted(keys):
+            key_list = key.split('|')
+            if len(key_list) != 2:  # error data in DB, log it and ignore
+                self.set_object_not_ok('PWM', key, 'Invalid key for PWM_INFO: {}'.format(key))
+                continue
+
+            name = key_list[1]
+            if config.ignore_devices and name in config.ignore_devices:
+                continue
+
+            data_dict = self._db.get_all(self._db.STATE_DB, key)
+
+            # Check PWM status field
+            status = data_dict.get('status', None)
+            if status is None:
+                self.set_object_not_ok('PWM', name, 'Failed to get status for {}'.format(name))
+                continue
+
+            if status == 'NOT_OK':
+                value = data_dict.get('value', 'N/A')
+                min_threshold = data_dict.get('min_threshold', 'N/A')
+                max_threshold = data_dict.get('max_threshold', 'N/A')
+                self.set_object_not_ok('PWM', name,
+                                       '{} value is out of range, value={}, range=[{},{}]'.format(
+                                           name, value, min_threshold, max_threshold))
+                continue
+
+            self.set_object_ok('PWM', name)
 
     def reset(self):
         self._info = {}

--- a/src/system-health/tests/test_system_health.py
+++ b/src/system-health/tests/test_system_health.py
@@ -514,6 +514,32 @@ def test_hardware_checker():
         }
     })
 
+    MockConnector.data.update({
+        'PWM_INFO|pwm': {
+            'name': 'pwm',
+            'value': '128',
+            'status': 'OK',
+            'min_threshold': '0',
+            'max_threshold': '255',
+            'minimum_value': '64',
+            'maximum_value': '192'
+        },
+        'PWM_INFO|pwm2': {
+            'name': 'pwm2',
+            'value': '300',
+            'status': 'NOT_OK',
+            'min_threshold': '0',
+            'max_threshold': '255',
+            'minimum_value': '128',
+            'maximum_value': '300'
+        },
+        'PWM_INFO|pwm3': {
+            'name': 'pwm3',
+            'value': '100'
+            # Missing status field
+        }
+    })
+
     checker = HardwareChecker()
     assert checker.get_category() == 'Hardware'
     config = Config()
@@ -582,6 +608,18 @@ def test_hardware_checker():
 
     assert 'liquid_cooling_6' in checker._info
     assert checker._info['liquid_cooling_6'][HealthChecker.INFO_FIELD_OBJECT_STATUS] == HealthChecker.STATUS_OK
+
+    # PWM checks
+    assert 'pwm' in checker._info
+    assert checker._info['pwm'][HealthChecker.INFO_FIELD_OBJECT_STATUS] == HealthChecker.STATUS_OK
+
+    assert 'pwm2' in checker._info
+    assert checker._info['pwm2'][HealthChecker.INFO_FIELD_OBJECT_STATUS] == HealthChecker.STATUS_NOT_OK
+    assert 'value is out of range' in checker._info['pwm2'][HealthChecker.INFO_FIELD_OBJECT_MSG]
+
+    assert 'pwm3' in checker._info
+    assert checker._info['pwm3'][HealthChecker.INFO_FIELD_OBJECT_STATUS] == HealthChecker.STATUS_NOT_OK
+    assert 'Failed to get status' in checker._info['pwm3'][HealthChecker.INFO_FIELD_OBJECT_MSG]
 
 
 def test_config():


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

